### PR TITLE
Switch linter from black/flake to ruff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 test.ipynb
 *.pyc
 docs/build
+.ruff_cache

--- a/dialogue2graph/__init__.py
+++ b/dialogue2graph/__init__.py
@@ -1,2 +1,2 @@
-from dialogue2graph.pipelines.core.dialogue import Dialogue
-from dialogue2graph.pipelines.core.graph import Graph
+from dialogue2graph.pipelines.core.dialogue import Dialogue as Dialogue
+from dialogue2graph.pipelines.core.graph import Graph as Graph

--- a/dialogue2graph/datasets/__init__.py
+++ b/dialogue2graph/datasets/__init__.py
@@ -1,1 +1,1 @@
-from dialogue2graph.datasets.core import Dataset
+from dialogue2graph.datasets.core import Dataset as Dataset

--- a/dialogue2graph/datasets/complex_dialogues/find_graph_ends.py
+++ b/dialogue2graph/datasets/complex_dialogues/find_graph_ends.py
@@ -38,7 +38,9 @@ def find_graph_ends(G: Graph, model: BaseChatModel) -> dict[str]:
     {{"ends": [id1, id2, ...], "description": "Brief explanation of your decision"}}
     """
 
-    graph_ends_prompt = PromptTemplate(input_variables=["json_graph"], template=graph_ends_prompt_template)
+    graph_ends_prompt = PromptTemplate(
+        input_variables=["json_graph"], template=graph_ends_prompt_template
+    )
 
     parser = PydanticOutputParser(pydantic_object=GraphEndsResult)
 

--- a/dialogue2graph/datasets/complex_dialogues/generation.py
+++ b/dialogue2graph/datasets/complex_dialogues/generation.py
@@ -18,7 +18,11 @@ from dialogue2graph.pipelines.core.schemas import GraphGenerationResult, Dialogu
 from dialogue2graph.pipelines.model_storage import ModelStorage
 from dialogue2graph.utils.prompt_caching import setup_cache, add_uuid_to_prompt
 
-from .prompts import cycle_graph_generation_prompt_informal, cycle_graph_repair_prompt, graph_example
+from .prompts import (
+    cycle_graph_generation_prompt_informal,
+    cycle_graph_repair_prompt,
+    graph_example,
+)
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -55,7 +59,9 @@ class CycleGraphGenerator(BaseModel):
     def __init__(self, **data):
         super().__init__(**data)
 
-    def invoke(self, model: BaseChatModel, prompt: PromptTemplate, seed=None, **kwargs) -> BaseGraph:
+    def invoke(
+        self, model: BaseChatModel, prompt: PromptTemplate, seed=None, **kwargs
+    ) -> BaseGraph:
         """
         Generate a cyclic dialogue graph based on the topic input.
         """
@@ -85,11 +91,17 @@ class GenerationPipeline(BaseModel):
     theme_validation_model: BaseChatModel
     validation_model: BaseChatModel
     graph_generator: CycleGraphGenerator = Field(default_factory=CycleGraphGenerator)
-    generation_prompt: Optional[PromptTemplate] = Field(default_factory=lambda: cycle_graph_generation_prompt_informal)
-    repair_prompt: Optional[PromptTemplate] = Field(default_factory=lambda: cycle_graph_repair_prompt)
+    generation_prompt: Optional[PromptTemplate] = Field(
+        default_factory=lambda: cycle_graph_generation_prompt_informal
+    )
+    repair_prompt: Optional[PromptTemplate] = Field(
+        default_factory=lambda: cycle_graph_repair_prompt
+    )
     min_cycles: int = 2
     max_fix_attempts: int = 3
-    dialogue_sampler: RecursiveDialogueSampler = Field(default_factory=RecursiveDialogueSampler)
+    dialogue_sampler: RecursiveDialogueSampler = Field(
+        default_factory=RecursiveDialogueSampler
+    )
     seed: Optional[int] = None
 
     class Config:
@@ -121,7 +133,9 @@ class GenerationPipeline(BaseModel):
         if self.seed:
             self.cache = setup_cache()
 
-    def validate_graph_cycle_requirement(self, graph: BaseGraph, min_cycles: int = 2) -> Dict[str, Any]:
+    def validate_graph_cycle_requirement(
+        self, graph: BaseGraph, min_cycles: int = 2
+    ) -> Dict[str, Any]:
         """Checks the graph for cycle requirements"""
         logger.info("🔍 Checking graph requirements...")
         try:
@@ -135,32 +149,54 @@ class GenerationPipeline(BaseModel):
             if meets_requirements:
                 logger.info("✅ Graph meets cycle requirements")
             else:
-                logger.info(f"❌ Graph doesn't meet cycle requirements (minimum {min_cycles} cycles needed)")
-            return {"meets_requirements": meets_requirements, "cycles": cycles, "cycles_count": cycles_count}
+                logger.info(
+                    f"❌ Graph doesn't meet cycle requirements (minimum {min_cycles} cycles needed)"
+                )
+            return {
+                "meets_requirements": meets_requirements,
+                "cycles": cycles,
+                "cycles_count": cycles_count,
+            }
 
         except Exception as e:
             logger.error(f"❌ Validation error: {str(e)}")
             raise
 
-    def check_and_fix_transitions(self, graph: BaseGraph, max_attempts: int = 3) -> Dict[str, Any]:
+    def check_and_fix_transitions(
+        self, graph: BaseGraph, max_attempts: int = 3
+    ) -> Dict[str, Any]:
         """Checks transitions in the graph and attempts to fix invalid ones via LLM"""
         logger.info("Validating initial graph")
-        initial_validation = are_triplets_valid(graph, self.validation_model, return_type="detailed")
+        initial_validation = are_triplets_valid(
+            graph, self.validation_model, return_type="detailed"
+        )
         logger.info("Finished validating initial graph")
         if initial_validation["is_valid"]:
-            return {"is_valid": True, "graph": graph, "validation_details": {"invalid_transitions": [], "attempts_made": 0, "fixed_count": 0}}
+            return {
+                "is_valid": True,
+                "graph": graph,
+                "validation_details": {
+                    "invalid_transitions": [],
+                    "attempts_made": 0,
+                    "fixed_count": 0,
+                },
+            }
 
         initial_invalid_count = len(initial_validation["invalid_transitions"])
         current_graph = graph
         current_attempt = 0
-        logger.warning(f"⚠️ Found these {initial_validation['invalid_transitions']} invalid transitions")
+        logger.warning(
+            f"⚠️ Found these {initial_validation['invalid_transitions']} invalid transitions"
+        )
         while current_attempt < max_attempts:
             logger.info(f"🔄 Fix attempt {current_attempt + 1}/{max_attempts}")
             try:
                 # Add UUID to repair prompt
                 if self.repair_prompt:
                     original_template = self.repair_prompt.template
-                    self.repair_prompt.template = add_uuid_to_prompt(original_template, seed=self.seed)
+                    self.repair_prompt.template = add_uuid_to_prompt(
+                        original_template, seed=self.seed
+                    )
 
                 current_graph = self.graph_generator.invoke(
                     model=self.generation_model,
@@ -180,15 +216,23 @@ class GenerationPipeline(BaseModel):
 
             current_attempt += 1
 
-        validation = are_triplets_valid(current_graph, self.validation_model, return_type="detailed")
+        validation = are_triplets_valid(
+            current_graph, self.validation_model, return_type="detailed"
+        )
         if validation["is_valid"]:
             return {
                 "is_valid": True,
                 "graph": current_graph,
-                "validation_details": {"invalid_transitions": [], "attempts_made": current_attempt + 1, "fixed_count": initial_invalid_count},
+                "validation_details": {
+                    "invalid_transitions": [],
+                    "attempts_made": current_attempt + 1,
+                    "fixed_count": initial_invalid_count,
+                },
             }
         else:
-            logger.warning(f"⚠️ Found these {validation['invalid_transitions']} invalid transitions after fix attempt")
+            logger.warning(
+                f"⚠️ Found these {validation['invalid_transitions']} invalid transitions after fix attempt"
+            )
             remaining_invalid = len(validation.get("invalid_transitions", []))
             return {
                 "is_valid": False,
@@ -205,16 +249,28 @@ class GenerationPipeline(BaseModel):
         try:
             logger.info("Generating Graph ...")
             graph = self.graph_generator.invoke(
-                model=self.generation_model, prompt=self.generation_prompt, graph_example=graph_example, topic=topic, seed=self.seed
+                model=self.generation_model,
+                prompt=self.generation_prompt,
+                graph_example=graph_example,
+                topic=topic,
+                seed=self.seed,
             )
             logger.info(f"Graph generated is {graph.graph_dict}")
             if not graph.edges_match_nodes():
-                return GenerationError(error_type=ErrorType.INVALID_GRAPH_STRUCTURE, message="Generated graph is wrong: edges don't match nodes")
+                return GenerationError(
+                    error_type=ErrorType.INVALID_GRAPH_STRUCTURE,
+                    message="Generated graph is wrong: edges don't match nodes",
+                )
             graph = graph.remove_duplicated_nodes()
             if graph is None:
-                return GenerationError(error_type=ErrorType.INVALID_GRAPH_STRUCTURE, message="Generated graph is wrong: utterances in nodes doubled")
+                return GenerationError(
+                    error_type=ErrorType.INVALID_GRAPH_STRUCTURE,
+                    message="Generated graph is wrong: utterances in nodes doubled",
+                )
 
-            cycle_validation = self.validate_graph_cycle_requirement(graph, self.min_cycles)
+            cycle_validation = self.validate_graph_cycle_requirement(
+                graph, self.min_cycles
+            )
             if not cycle_validation["meets_requirements"]:
                 return GenerationError(
                     error_type=ErrorType.TOO_MANY_CYCLES,
@@ -226,19 +282,27 @@ class GenerationPipeline(BaseModel):
             logger.info(f"Sampled {len(sampled_dialogues)} dialogues")
             if not match_triplets_dg(graph, sampled_dialogues)["value"]:
                 return GenerationError(
-                    error_type=ErrorType.SAMPLING_FAILED, message="Failed to sample valid dialogues - not all utterances are present"
+                    error_type=ErrorType.SAMPLING_FAILED,
+                    message="Failed to sample valid dialogues - not all utterances are present",
                 )
 
             theme_validation = is_theme_valid(graph, self.theme_validation_model, topic)
             if not theme_validation["value"]:
-                return GenerationError(error_type=ErrorType.INVALID_THEME, message=f"Theme validation failed: {theme_validation['description']}")
+                return GenerationError(
+                    error_type=ErrorType.INVALID_THEME,
+                    message=f"Theme validation failed: {theme_validation['description']}",
+                )
 
             logger.info("Validating and fixing transitions...")
-            transition_validation = self.check_and_fix_transitions(graph=graph, max_attempts=self.max_fix_attempts)
+            transition_validation = self.check_and_fix_transitions(
+                graph=graph, max_attempts=self.max_fix_attempts
+            )
             logger.info("Finished validating and fixing transitions")
 
             if not transition_validation["is_valid"]:
-                invalid_transitions = transition_validation["validation_details"]["invalid_transitions"]
+                invalid_transitions = transition_validation["validation_details"][
+                    "invalid_transitions"
+                ]
                 return GenerationError(
                     error_type=ErrorType.INVALID_GRAPH_STRUCTURE,
                     message=f"Found {len(invalid_transitions)} invalid transitions "
@@ -248,28 +312,40 @@ class GenerationPipeline(BaseModel):
             graph = transition_validation["graph"]
             if transition_validation["validation_details"]["attempts_made"]:
                 if not graph.edges_match_nodes():
-                    return GenerationError(error_type=ErrorType.INVALID_GRAPH_STRUCTURE, message="Generated graph is wrong: edges don't match nodes")
+                    return GenerationError(
+                        error_type=ErrorType.INVALID_GRAPH_STRUCTURE,
+                        message="Generated graph is wrong: edges don't match nodes",
+                    )
                 graph = graph.remove_duplicated_nodes()
                 if graph is None:
                     return GenerationError(
-                        error_type=ErrorType.INVALID_GRAPH_STRUCTURE, message="Generated graph is wrong: utterances in nodes doubled"
+                        error_type=ErrorType.INVALID_GRAPH_STRUCTURE,
+                        message="Generated graph is wrong: utterances in nodes doubled",
                     )
                 print("Sampling dialogues...")
                 sampled_dialogues = self.dialogue_sampler.invoke(graph, 15)
                 print(f"Sampled {len(sampled_dialogues)} dialogues")
                 if not match_triplets_dg(graph, sampled_dialogues)["value"]:
                     return GenerationError(
-                        error_type=ErrorType.SAMPLING_FAILED, message="Failed to sample valid dialogues - not all utterances are present"
+                        error_type=ErrorType.SAMPLING_FAILED,
+                        message="Failed to sample valid dialogues - not all utterances are present",
                     )
 
             logger.info(f"going to return: {transition_validation['graph'].graph_dict}")
-            ret = GraphGenerationResult(graph=transition_validation["graph"].graph_dict, topic=topic, dialogues=sampled_dialogues)
+            ret = GraphGenerationResult(
+                graph=transition_validation["graph"].graph_dict,
+                topic=topic,
+                dialogues=sampled_dialogues,
+            )
             logger.info(f"ret: {ret}")
             return ret
 
         except Exception as e:
             logger.error(f"Unexpected error during generation: {str(e)}")
-            return GenerationError(error_type=ErrorType.GENERATION_FAILED, message=f"Unexpected error during generation: {str(e)}")
+            return GenerationError(
+                error_type=ErrorType.GENERATION_FAILED,
+                message=f"Unexpected error during generation: {str(e)}",
+            )
 
     def __call__(self, topic: str) -> PipelineResult:
         """Shorthand for generate_and_validate"""
@@ -300,7 +376,9 @@ class LoopedGraphGenerator(TopicGraphGenerator):
             pipeline=GenerationPipeline(
                 generation_model=model_storage.storage[generation_llm].model,
                 validation_model=model_storage.storage[validation_llm].model,
-                theme_validation_model=model_storage.storage[theme_validation_llm].model,
+                theme_validation_model=model_storage.storage[
+                    theme_validation_llm
+                ].model,
                 generation_prompt=cycle_graph_generation_prompt_informal,
                 repair_prompt=cycle_graph_repair_prompt,
             ),
@@ -322,7 +400,9 @@ class LoopedGraphGenerator(TopicGraphGenerator):
                     {
                         "graph": result.graph.model_dump(),
                         "topic": result.topic,
-                        "dialogues": [dia.model_dump() for dia in result.dialogues],  # The dialogues are already dictionaries
+                        "dialogues": [
+                            dia.model_dump() for dia in result.dialogues
+                        ],  # The dialogues are already dictionaries
                     }
                 )
             else:

--- a/dialogue2graph/datasets/complex_dialogues/prompts.py
+++ b/dialogue2graph/datasets/complex_dialogues/prompts.py
@@ -340,50 +340,115 @@ Return ONLY the complete fixed graph JSON with the same structure.
 )
 graph_example = {
     "edges": [
-        {"source": 1, "target": 2, "utterances": ["I'm looking for an Indian restaurant, preferably in the centre of town."]},
+        {
+            "source": 1,
+            "target": 2,
+            "utterances": [
+                "I'm looking for an Indian restaurant, preferably in the centre of town."
+            ],
+        },
         {"source": 2, "target": 5, "utterances": ["I would prefer cheap restaurants."]},
-        {"source": 5, "target": 7, "utterances": ["Sure please book a table there fore 7 people at 12:15 on saturday"]},
+        {
+            "source": 5,
+            "target": 7,
+            "utterances": [
+                "Sure please book a table there fore 7 people at 12:15 on saturday"
+            ],
+        },
         {
             "source": 1,
             "target": 5,
-            "utterances": ["I am looking for a restaurant. The restaurant should be in the moderate price range and should be in the east"],
+            "utterances": [
+                "I am looking for a restaurant. The restaurant should be in the moderate price range and should be in the east"
+            ],
         },
-        {"source": 5, "target": 10, "utterances": ["The restaurant should serve italian food."]},
-        {"source": 6, "target": 7, "utterances": ["I will have 5 people and we would like 12:15 if possible. Thanks."]},
+        {
+            "source": 5,
+            "target": 10,
+            "utterances": ["The restaurant should serve italian food."],
+        },
+        {
+            "source": 6,
+            "target": 7,
+            "utterances": [
+                "I will have 5 people and we would like 12:15 if possible. Thanks."
+            ],
+        },
         {
             "source": 7,
             "target": 9,
-            "utterances": ["No that's all I needed. Thank you!", "Thanks for you help. I only need the restaurant reservation. Goodbye."],
+            "utterances": [
+                "No that's all I needed. Thank you!",
+                "Thanks for you help. I only need the restaurant reservation. Goodbye.",
+            ],
         },
-        {"source": 10, "target": 11, "utterances": ["What other restaurants in that area serve Italian food?"]},
-        {"source": 11, "target": 6, "utterances": ["No, that will do. Can I book a table for monday?"]},
+        {
+            "source": 10,
+            "target": 11,
+            "utterances": ["What other restaurants in that area serve Italian food?"],
+        },
+        {
+            "source": 11,
+            "target": 6,
+            "utterances": ["No, that will do. Can I book a table for monday?"],
+        },
         {
             "source": 1,
             "target": 3,
-            "utterances": ["I'm looking for a place to dine on the south side of town. Please find a place that's in the expensive price range."],
+            "utterances": [
+                "I'm looking for a place to dine on the south side of town. Please find a place that's in the expensive price range."
+            ],
         },
         {
             "source": 3,
             "target": 8,
-            "utterances": ["Do you have a favorite you could recommend? I will need the phone and postcode and food type also please."],
+            "utterances": [
+                "Do you have a favorite you could recommend? I will need the phone and postcode and food type also please."
+            ],
         },
-        {"source": 1, "target": 4, "utterances": ["I am looking for a cheap restaurant in the centre."]},
-        {"source": 4, "target": 8, "utterances": ["Yes, may I have the address, postcode, and phone number for Golden House? I'll book it myself."]},
-        {"source": 8, "target": 9, "utterances": ["No, that will be it. Thank you for your help.", "Thanks, that's all I need. Have a nice day."]},
+        {
+            "source": 1,
+            "target": 4,
+            "utterances": ["I am looking for a cheap restaurant in the centre."],
+        },
+        {
+            "source": 4,
+            "target": 8,
+            "utterances": [
+                "Yes, may I have the address, postcode, and phone number for Golden House? I'll book it myself."
+            ],
+        },
+        {
+            "source": 8,
+            "target": 9,
+            "utterances": [
+                "No, that will be it. Thank you for your help.",
+                "Thanks, that's all I need. Have a nice day.",
+            ],
+        },
     ],
     "nodes": [
-        {"id": 1, "label": "start", "is_start": True, "utterances": ["Hello! How can I help you?"]},
+        {
+            "id": 1,
+            "label": "start",
+            "is_start": True,
+            "utterances": ["Hello! How can I help you?"],
+        },
         {
             "id": 2,
             "label": "ask_price_range",
             "is_start": False,
-            "utterances": ["There are a number of options for Indian restaurants in the centre of town. What price range would you like?"],
+            "utterances": [
+                "There are a number of options for Indian restaurants in the centre of town. What price range would you like?"
+            ],
         },
         {
             "id": 3,
             "label": "ask_cuisine_preference",
             "is_start": False,
-            "utterances": ["I found five expensive restaurants on the south side of town. Would you prefer Chinese, Indian, Italian or Mexican?"],
+            "utterances": [
+                "I found five expensive restaurants on the south side of town. Would you prefer Chinese, Indian, Italian or Mexican?"
+            ],
         },
         {
             "id": 4,
@@ -406,7 +471,9 @@ graph_example = {
             "id": 6,
             "label": "ask_reservation_details",
             "is_start": False,
-            "utterances": ["Absolutely, how many people will you have and what time are you wanting the reservation?"],
+            "utterances": [
+                "Absolutely, how many people will you have and what time are you wanting the reservation?"
+            ],
         },
         {
             "id": 7,
@@ -441,7 +508,9 @@ graph_example = {
             "id": 10,
             "label": "offer_reservation",
             "is_start": False,
-            "utterances": ["Pizza hut fen ditton serves italian food in the east, would you like a reservation?"],
+            "utterances": [
+                "Pizza hut fen ditton serves italian food in the east, would you like a reservation?"
+            ],
         },
         {
             "id": 11,

--- a/dialogue2graph/metrics/algorithm_registry.py
+++ b/dialogue2graph/metrics/algorithm_registry.py
@@ -14,7 +14,11 @@ class AlgorithmRegistry:
     def register(cls, name=None, input_type=None, output_type=None):
         def decorator(func):
             algorithm_name = name or func.__name__
-            cls._algorithms[algorithm_name] = {"type": func, "input_type": input_type, "output_type": output_type}
+            cls._algorithms[algorithm_name] = {
+                "type": func,
+                "input_type": input_type,
+                "output_type": output_type,
+            }
             return func
 
         return decorator
@@ -25,4 +29,8 @@ class AlgorithmRegistry:
 
     @classmethod
     def get_by_category(cls, category):
-        return {name: data for name, data in cls._algorithms.items() if data["category"] == category}
+        return {
+            name: data
+            for name, data in cls._algorithms.items()
+            if data["category"] == category
+        }

--- a/dialogue2graph/metrics/llm_metrics/__init__.py
+++ b/dialogue2graph/metrics/llm_metrics/__init__.py
@@ -1,1 +1,13 @@
-from .metrics import are_triplets_valid, is_theme_valid, compare_graphs, GraphValidationResult
+from .metrics import (
+    are_triplets_valid,
+    is_theme_valid,
+    compare_graphs,
+    GraphValidationResult,
+)
+
+__all__ = [
+    "are_triplets_valid",
+    "is_theme_valid",
+    "compare_graphs",
+    "GraphValidationResult",
+]

--- a/dialogue2graph/metrics/llm_metrics/metrics.py
+++ b/dialogue2graph/metrics/llm_metrics/metrics.py
@@ -38,7 +38,9 @@ class GraphValidationResult(TypedDict):
     invalid_transitions: List[InvalidTransition]
 
 
-def are_triplets_valid(G: Graph, model: BaseChatModel, return_type: str = "dict") -> Union[dict, GraphValidationResult]:
+def are_triplets_valid(
+    G: Graph, model: BaseChatModel, return_type: str = "dict"
+) -> Union[dict, GraphValidationResult]:
     """
     Validates dialogue graph structure and logical transitions between nodes.
 
@@ -62,7 +64,12 @@ def are_triplets_valid(G: Graph, model: BaseChatModel, return_type: str = "dict"
 
     # Create prompt template
     triplet_validate_prompt = PromptTemplate(
-        input_variables=["json_graph", "source_utterances", "edge_utterances", "target_utterances"],
+        input_variables=[
+            "json_graph",
+            "source_utterances",
+            "edge_utterances",
+            "target_utterances",
+        ],
         template="""
     You are evaluating if dialog transitions make logical sense.
     
@@ -101,11 +108,15 @@ def are_triplets_valid(G: Graph, model: BaseChatModel, return_type: str = "dict"
         target_id = edge["target"]
 
         if source_id not in node_map or target_id not in node_map:
-            description = f"Invalid edge: missing node reference {source_id} -> {target_id}"
+            description = (
+                f"Invalid edge: missing node reference {source_id} -> {target_id}"
+            )
             is_valid = False
             descriptions.append(description)
             if return_type == "detailed":
-                invalid_transitions.append({"from_": [], "user": [], "to": [], "reason": description})
+                invalid_transitions.append(
+                    {"from_": [], "user": [], "to": [], "reason": description}
+                )
             continue
 
         # Get utterances
@@ -129,11 +140,21 @@ def are_triplets_valid(G: Graph, model: BaseChatModel, return_type: str = "dict"
             descriptions.append(result.description)
             if return_type == "detailed":
                 invalid_transitions.append(
-                    {"from_": source_node["utterances"], "user": edge["utterances"], "to": target_node["utterances"], "reason": result.description}
+                    {
+                        "from_": source_node["utterances"],
+                        "user": edge["utterances"],
+                        "to": target_node["utterances"],
+                        "reason": result.description,
+                    }
                 )
 
     if return_type == "dict":
-        return {"value": is_valid, "description": " ".join(descriptions) if descriptions else "All transitions are valid."}
+        return {
+            "value": is_valid,
+            "description": " ".join(descriptions)
+            if descriptions
+            else "All transitions are valid.",
+        }
     else:  # return_type == "detailed"
         return {"is_valid": is_valid, "invalid_transitions": invalid_transitions}
 
@@ -221,7 +242,9 @@ def _compare_edge_lens(G1: BaseGraph, G2: BaseGraph, max: list) -> bool:
             return False
         for edge1 in edges1:
             for edge2 in edges2:
-                if nodes_map[edge1["target"]] == edge2["target"] and len(edge1["utterances"]) != len(edge2["utterances"]):
+                if nodes_map[edge1["target"]] == edge2["target"] and len(
+                    edge1["utterances"]
+                ) != len(edge2["utterances"]):
                     return False
     return True
 
@@ -249,29 +272,51 @@ def compare_graphs(
     nodes2_list = G2.nodes2list()
 
     if len(nodes1_list) != len(nodes2_list):
-        return {"value": False, "description": f"Numbers of nodes do not match: {len(nodes1_list)} != {len(nodes2_list)}"}
+        return {
+            "value": False,
+            "description": f"Numbers of nodes do not match: {len(nodes1_list)} != {len(nodes2_list)}",
+        }
 
     # g1_list, g2_list - concatenations of utterances of every node and its outgoing edges
     g1_list, n_edge_utts1 = G1.graph2list()
     g2_list, n_edge_utts2 = G2.graph2list()
 
-    nodes_matrix = get_similarity(nodes1_list, nodes2_list, embedder, device=device)  # embeddings for utterances in nodes
-    mix_matrix = get_similarity(g1_list, g2_list, embedder, device=device)  # embeddings for utterances in nodes+edges
+    nodes_matrix = get_similarity(
+        nodes1_list, nodes2_list, embedder, device=device
+    )  # embeddings for utterances in nodes
+    mix_matrix = get_similarity(
+        g1_list, g2_list, embedder, device=device
+    )  # embeddings for utterances in nodes+edges
 
     nodes_max = list(np.argmax(nodes_matrix, axis=1))
     mix_max = list(np.argmax(mix_matrix, axis=1))
     if nodes_max != mix_max:
-        return {"value": False, "description": f"Mapping for nodes {nodes_max} doesn't match mapping for nodes+edges {mix_max}"}
+        return {
+            "value": False,
+            "description": f"Mapping for nodes {nodes_max} doesn't match mapping for nodes+edges {mix_max}",
+        }
     if len(set(nodes_max)) < len(nodes1_list):
-        return {"value": False, "description": "At least one of nodes corresponds to more than one in another graph"}
+        return {
+            "value": False,
+            "description": "At least one of nodes corresponds to more than one in another graph",
+        }
 
     if n_edge_utts1 != n_edge_utts2:
-        return {"value": False, "description": "Graphs have different number of user's utterances"}
+        return {
+            "value": False,
+            "description": "Graphs have different number of user's utterances",
+        }
     if len(set(mix_max)) < len(g1_list):
-        return {"value": False, "description": "At least one of nodes concatenated with edges corresponds to more than one in another graph"}
+        return {
+            "value": False,
+            "description": "At least one of nodes concatenated with edges corresponds to more than one in another graph",
+        }
 
     if not _compare_edge_lens(G1, G2, mix_max):
-        return {"value": False, "description": "At least one pair of edges has different number of utterances"}
+        return {
+            "value": False,
+            "description": "At least one pair of edges has different number of utterances",
+        }
 
     nodes_min = np.min(np.max(nodes_matrix, axis=1))
     mix_min = np.min(np.max(mix_matrix, axis=1))
@@ -279,13 +324,21 @@ def compare_graphs(
     full_min = min(nodes_min, mix_min)
 
     if full_min >= sim_th:
-        return {"value": True, "description": f"Nodes similarity: {nodes_min}, Nodes+edges similarity: {mix_min}"}
+        return {
+            "value": True,
+            "description": f"Nodes similarity: {nodes_min}, Nodes+edges similarity: {mix_min}",
+        }
 
     parser = PydanticOutputParser(pydantic_object=CompareResponse)
     format_model = ChatOpenAI(model=formatter)
     model = ChatOpenAI(model=llm_comparer)
     fixed_output_parser = OutputFixingParser.from_llm(parser=parser, llm=format_model)
     chain = model | fixed_output_parser
-    query = compare_graphs_prompt.format(result_form=CompareResponse().model_dump(), graph_example=graph_example, graph_1=g1, graph_2=g2)
+    query = compare_graphs_prompt.format(
+        result_form=CompareResponse().model_dump(),
+        graph_example=graph_example,
+        graph_1=g1,
+        graph_2=g2,
+    )
     messages = [HumanMessage(content=query)]
     return chain.invoke(messages)

--- a/dialogue2graph/metrics/llm_metrics/prompts.py
+++ b/dialogue2graph/metrics/llm_metrics/prompts.py
@@ -17,7 +17,11 @@ compare_graphs_prompt = PromptTemplate.from_template(
 
 graph_example = {
     "edges": [
-        {"source": 1, "target": 2, "utterances": ["I need to make an order", "I want to order from you"]},
+        {
+            "source": 1,
+            "target": 2,
+            "utterances": ["I need to make an order", "I want to order from you"],
+        },
         {
             "source": 2,
             "target": 3,
@@ -30,19 +34,33 @@ graph_example = {
         {"source": 4, "target": 2, "utterances": ["Start new order"]},
     ],
     "nodes": [
-        {"id": 1, "label": "start", "is_start": True, "utterances": ["How can I help?", "Hello"]},
-        {"id": 2, "label": "ask_books", "is_start": False, "utterances": ["What books do you like?"]},
+        {
+            "id": 1,
+            "label": "start",
+            "is_start": True,
+            "utterances": ["How can I help?", "Hello"],
+        },
+        {
+            "id": 2,
+            "label": "ask_books",
+            "is_start": False,
+            "utterances": ["What books do you like?"],
+        },
         {
             "id": 3,
             "label": "ask_payment_method",
             "is_start": False,
-            "utterances": ["Please, enter the payment method you would like to use: cash or credit card."],
+            "utterances": [
+                "Please, enter the payment method you would like to use: cash or credit card."
+            ],
         },
         {
             "id": 4,
             "label": "ask_to_redo",
             "is_start": False,
-            "utterances": ["Something is wrong, can you please use other payment method or start order again"],
+            "utterances": [
+                "Something is wrong, can you please use other payment method or start order again"
+            ],
         },
     ],
     "reason": "",

--- a/dialogue2graph/metrics/no_llm_metrics/__init__.py
+++ b/dialogue2graph/metrics/no_llm_metrics/__init__.py
@@ -8,3 +8,14 @@ from .metrics import (
     is_correct_length,
     is_same_structure,
 )
+
+__all__ = [
+    "are_paths_valid",
+    "DialogueValidationResult",
+    "match_graph_triplets",
+    "match_triplets_dg",
+    "DGTripletsMatchResult",
+    "match_roles",
+    "is_correct_length",
+    "is_same_structure",
+]

--- a/dialogue2graph/metrics/no_llm_metrics/metrics.py
+++ b/dialogue2graph/metrics/no_llm_metrics/metrics.py
@@ -31,7 +31,9 @@ def _collapse_multiedges(edges):
     return collapsed_edges
 
 
-def _get_jaccard_edges(true_graph_edges, generated_graph_edges, verbose=False, return_matrix=False):
+def _get_jaccard_edges(
+    true_graph_edges, generated_graph_edges, verbose=False, return_matrix=False
+):
     """
     Calculates Jaccard similarity between edges of the original graph and the generated graph.
 
@@ -63,7 +65,9 @@ def _get_jaccard_edges(true_graph_edges, generated_graph_edges, verbose=False, r
         for idx2, (k2, v2) in enumerate(generated_graph_edges.items()):
             intersect_set = set(v1).intersection(set(v2))
             union_set = set(v1).union(set(v2))
-            jaccard_values[idx1][idx2] = len(intersect_set) / len(union_set) if len(union_set) > 0 else 0.0
+            jaccard_values[idx1][idx2] = (
+                len(intersect_set) / len(union_set) if len(union_set) > 0 else 0.0
+            )
 
             if verbose:
                 print(k1, v1)
@@ -104,7 +108,9 @@ def _collapse_multinodes(nodes):
     return collapsed_nodes
 
 
-def _get_jaccard_nodes(true_graph_nodes, generated_graph_nodes, verbose=False, return_matrix=False):
+def _get_jaccard_nodes(
+    true_graph_nodes, generated_graph_nodes, verbose=False, return_matrix=False
+):
     """
     Calculates Jaccard similarity between nodes of the original graph and the generated graph.
 
@@ -130,7 +136,9 @@ def _get_jaccard_nodes(true_graph_nodes, generated_graph_nodes, verbose=False, r
     true_graph_nodes = _collapse_multinodes(list(true_graph_nodes))
     generated_graph_nodes = _collapse_multinodes(list(generated_graph_nodes))
 
-    jaccard_values = np.zeros((len(true_graph_nodes) + 1, len(generated_graph_nodes) + 1))
+    jaccard_values = np.zeros(
+        (len(true_graph_nodes) + 1, len(generated_graph_nodes) + 1)
+    )
     print(true_graph_nodes)
     for node1_id, node1_utterances in true_graph_nodes.items():
         for node2_id, node2_utterances in generated_graph_nodes.items():
@@ -140,7 +148,11 @@ def _get_jaccard_nodes(true_graph_nodes, generated_graph_nodes, verbose=False, r
             jaccard_nominator = node1_utterances.intersection(node2_utterances)
             jaccard_denominator = node1_utterances.union(node2_utterances)
 
-            jaccard_values[node1_id][node2_id] = len(jaccard_nominator) / len(jaccard_denominator) if len(jaccard_denominator) > 0 else 0.0
+            jaccard_values[node1_id][node2_id] = (
+                len(jaccard_nominator) / len(jaccard_denominator)
+                if len(jaccard_denominator) > 0
+                else 0.0
+            )
 
             if verbose:
                 print(node1_utterances)
@@ -199,10 +211,19 @@ def match_graph_triplets(G1: BaseGraph, G2: BaseGraph, change_to_original_ids=Fa
     node_mapping = {node: None for node in g1.nodes}
     node_mapping.update({node: None for node in g2.nodes})
     if isinstance(g1, nx.DiGraph):
-        GM = nx.isomorphism.DiGraphMatcher(g1, g2, edge_match=lambda x, y: set(x["utterances"]).intersection(set(y["utterances"])) is not None)
+        GM = nx.isomorphism.DiGraphMatcher(
+            g1,
+            g2,
+            edge_match=lambda x, y: set(x["utterances"]).intersection(
+                set(y["utterances"])
+            )
+            is not None,
+        )
         are_isomorphic = GM.is_isomorphic()
     else:
-        GM = nx.isomorphism.MultiDiGraphMatcher(g1, g2, edge_match=_match_edge_for_multigraph)
+        GM = nx.isomorphism.MultiDiGraphMatcher(
+            g1, g2, edge_match=_match_edge_for_multigraph
+        )
         are_isomorphic = GM.is_isomorphic()
     if are_isomorphic:
         print("Graphs are isomorphic")
@@ -214,8 +235,12 @@ def match_graph_triplets(G1: BaseGraph, G2: BaseGraph, change_to_original_ids=Fa
     edges1 = list(_collapse_multiedges(g1.edges(data=True)).keys())
     edges2 = list(_collapse_multiedges(g2.edges(data=True)).keys())
 
-    _, _, matrix_edges = _get_jaccard_edges(g1.edges(data=True), g2.edges(data=True), verbose=False, return_matrix=True)
-    _, _, matrix_nodes = _get_jaccard_nodes(g1.nodes(data=True), g2.nodes(data=True), verbose=False, return_matrix=True)
+    _, _, matrix_edges = _get_jaccard_edges(
+        g1.edges(data=True), g2.edges(data=True), verbose=False, return_matrix=True
+    )
+    _, _, matrix_nodes = _get_jaccard_nodes(
+        g1.nodes(data=True), g2.nodes(data=True), verbose=False, return_matrix=True
+    )
 
     for i, edge1 in enumerate(edges1):
         edge_mapping[edge1] = None
@@ -224,9 +249,15 @@ def match_graph_triplets(G1: BaseGraph, G2: BaseGraph, change_to_original_ids=Fa
             if matrix_edges[i][j] > 0:
                 node1_src, node1_trg = _parse_edge(edge1)
                 node2_src, node2_trg = _parse_edge(edge2)
-                if matrix_nodes[node1_src][node2_src] == 0.0 and matrix_nodes[node1_trg][node2_trg] == 0.0:
+                if (
+                    matrix_nodes[node1_src][node2_src] == 0.0
+                    and matrix_nodes[node1_trg][node2_trg] == 0.0
+                ):
                     continue
-                elif matrix_nodes[node1_src][node2_src] > 0 and matrix_nodes[node1_trg][node2_trg] > 0:
+                elif (
+                    matrix_nodes[node1_src][node2_src] > 0
+                    and matrix_nodes[node1_trg][node2_trg] > 0
+                ):
                     if matrix_edges[i][j] > mapping_jaccard_values[edge1]:
                         mapping_jaccard_values[edge1] = matrix_edges[i][j]
                         edge_mapping[edge1] = edge2
@@ -243,12 +274,18 @@ def match_graph_triplets(G1: BaseGraph, G2: BaseGraph, change_to_original_ids=Fa
                     if node1_trg_nx == node2_trg_nx:
                         node_mapping[node1_trg + 1] = node2_trg + 1
                     print(
-                        f"""The nodes of edges {edges1[i]} and {edges2[j]} has something in common, but not complete match: Sources: {
-                            node1_src_nx["utterances"]}, {node2_src_nx["utterances"]}"""
+                        f"""The nodes of edges {edges1[i]} and {
+                            edges2[j]
+                        } has something in common, but not complete match: Sources: {
+                            node1_src_nx["utterances"]
+                        }, {node2_src_nx["utterances"]}"""
                     )
                     print(
-                        f"""The nodes of edges {edges1[i]} and {edges2[j]} has something in common, but not complete match: Targets: {
-                            node1_trg_nx["utterances"]}, {node2_trg_nx["utterances"]}"""
+                        f"""The nodes of edges {edges1[i]} and {
+                            edges2[j]
+                        } has something in common, but not complete match: Targets: {
+                            node1_trg_nx["utterances"]
+                        }, {node2_trg_nx["utterances"]}"""
                     )
 
     if G1.node_mapping != {} and change_to_original_ids:
@@ -266,7 +303,9 @@ def match_graph_triplets(G1: BaseGraph, G2: BaseGraph, change_to_original_ids=Fa
 
         for edge1, edge2 in edge_mapping.items():
             src1, trg1 = edge1.split("->")
-            new_edge_mapping[f"{inverse_mapping[int(src1)]}->{inverse_mapping[int(trg1)]}"] = edge2
+            new_edge_mapping[
+                f"{inverse_mapping[int(src1)]}->{inverse_mapping[int(trg1)]}"
+            ] = edge2
         return new_node_mapping, new_edge_mapping
 
     return node_mapping, edge_mapping
@@ -286,9 +325,22 @@ def _get_dialogue_triplets(seq: list[Dialogue]) -> set[tuple[str]]:
     """Find all dialogue triplets with (source, edge, target) utterances"""
     result = []
     for dialogue in seq:
-        assist_texts = [d.text.lower() for d in dialogue.messages if d.participant == "assistant"]
-        user_texts = [d.text.lower() for d in dialogue.messages if d.participant == "user"]
-        result.extend([(a1, u, a2) for a1, u, a2 in zip(assist_texts[:-1], user_texts[: len(assist_texts) - 1], assist_texts[1:])])
+        assist_texts = [
+            d.text.lower() for d in dialogue.messages if d.participant == "assistant"
+        ]
+        user_texts = [
+            d.text.lower() for d in dialogue.messages if d.participant == "user"
+        ]
+        result.extend(
+            [
+                (a1, u, a2)
+                for a1, u, a2 in zip(
+                    assist_texts[:-1],
+                    user_texts[: len(assist_texts) - 1],
+                    assist_texts[1:],
+                )
+            ]
+        )
     return set(result)
 
 
@@ -302,7 +354,9 @@ def _get_graph_triplets(G: BaseGraph):
         for edge in [e for e in edges if e["source"] == node["id"]]:
             for utt in edge["utterances"]:
                 for utt1 in node["utterances"]:
-                    for utt2 in [n for n in nodes if n["id"] == edge["target"]][0]["utterances"]:
+                    for utt2 in [n for n in nodes if n["id"] == edge["target"]][0][
+                        "utterances"
+                    ]:
                         result.append((utt1.lower(), utt.lower(), utt2.lower()))
     return set(result)
 
@@ -348,13 +402,17 @@ def match_triplets_dg(G: BaseGraph, dialogues: list[Dialogue]) -> DGTripletsMatc
         return {
             "value": False,
             "description": "Triplets missing in dialogues",
-            "absent_triplets": [AbsentTriplet.from_tuple(triplet) for triplet in dialogue_absent],
+            "absent_triplets": [
+                AbsentTriplet.from_tuple(triplet) for triplet in dialogue_absent
+            ],
         }
     else:
         return {
             "value": False,
             "description": "Triplets missing in graph",
-            "absent_triplets": [AbsentTriplet.from_tuple(triplet) for triplet in graph_absent],
+            "absent_triplets": [
+                AbsentTriplet.from_tuple(triplet) for triplet in graph_absent
+            ],
         }
 
 
@@ -431,7 +489,9 @@ class DialogueValidationResult(TypedDict):
     invalid_transitions: Optional[List[InvalidDialogueTransition]]
 
 
-def are_paths_valid(G: BaseGraph, dialogues: list[Dialogue]) -> DialogueValidationResult:
+def are_paths_valid(
+    G: BaseGraph, dialogues: list[Dialogue]
+) -> DialogueValidationResult:
     """
     Check if all dialogues are valid paths in the graph.
 
@@ -520,7 +580,9 @@ def all_utterances_present(G: BaseGraph, dialogues: List[Dialogue]):
         return graph_utterances.difference(dialogue_utterances)
 
 
-def triplet_match_accuracy(G1: BaseGraph, G2: BaseGraph, change_to_original_ids: bool = False) -> dict:
+def triplet_match_accuracy(
+    G1: BaseGraph, G2: BaseGraph, change_to_original_ids: bool = False
+) -> dict:
     """
     Calculates a simple accuracy metric for node and edge matching based on 'match_graph_triplets'.
 
@@ -530,7 +592,9 @@ def triplet_match_accuracy(G1: BaseGraph, G2: BaseGraph, change_to_original_ids:
             "edge_accuracy": fraction_of_matched_edges_in_G1
         }
     """
-    node_mapping, edge_mapping = match_graph_triplets(G1, G2, change_to_original_ids=change_to_original_ids)
+    node_mapping, edge_mapping = match_graph_triplets(
+        G1, G2, change_to_original_ids=change_to_original_ids
+    )
 
     # Count matching nodes
     g1_nodes = set(G1.graph.nodes())
@@ -540,7 +604,9 @@ def triplet_match_accuracy(G1: BaseGraph, G2: BaseGraph, change_to_original_ids:
 
     # Count matching edges
     g1_edges = list(G1.graph.edges())
-    matched_edges = sum(1 for edge_str in edge_mapping if edge_mapping[edge_str] is not None)
+    matched_edges = sum(
+        1 for edge_str in edge_mapping if edge_mapping[edge_str] is not None
+    )
     total_edges = len(g1_edges)
     edge_accuracy = matched_edges / total_edges if total_edges > 0 else 0.0
 
@@ -596,7 +662,9 @@ def compute_graph_metrics(graph_list: List[BaseGraph]) -> dict:
 
     average_edges_amount = total_edges / total_graphs if total_graphs > 0 else 0.0
     average_nodes_amount = total_nodes / total_graphs if total_graphs > 0 else 0.0
-    percentage_with_cycles = (with_cycles / total_graphs * 100) if total_graphs > 0 else 0.0
+    percentage_with_cycles = (
+        (with_cycles / total_graphs * 100) if total_graphs > 0 else 0.0
+    )
 
     return {
         "with_cycles": with_cycles,

--- a/dialogue2graph/metrics/similarity.py
+++ b/dialogue2graph/metrics/similarity.py
@@ -5,24 +5,37 @@ from langchain.evaluation import load_evaluator
 preloaded_models = {}
 
 
-def compare_strings(first: str, second: str, embedder: HuggingFaceEmbeddings, embedder_th: float = 0.001) -> bool:
+def compare_strings(
+    first: str, second: str, embedder: HuggingFaceEmbeddings, embedder_th: float = 0.001
+) -> bool:
     """Calculate pairwise_embedding_distance between two strings based on embedder
     and return True when threshold embedder_th not exceeded
     Return False otherwise"""
 
     evaluator_2 = load_evaluator("pairwise_embedding_distance", embeddings=embedder)
-    score = evaluator_2.evaluate_string_pairs(prediction=first, prediction_b=second)["score"]
+    score = evaluator_2.evaluate_string_pairs(prediction=first, prediction_b=second)[
+        "score"
+    ]
     # print("SCORE: ", score)
     return score <= embedder_th
 
 
-def get_similarity(generated: list[str], golden: list[str], model_name: str = "BAAI/bge-m3", device="cuda:0"):
+def get_similarity(
+    generated: list[str],
+    golden: list[str],
+    model_name: str = "BAAI/bge-m3",
+    device="cuda:0",
+):
     """ "Calculate similarity matrix between generated and golden using model model_name"""
 
     if model_name not in preloaded_models:
         preloaded_models[model_name] = SentenceTransformer(model_name, device=device)
 
-    golden_vectors = preloaded_models[model_name].encode(golden, normalize_embeddings=True)
-    generated_vectors = preloaded_models[model_name].encode(generated, normalize_embeddings=True)
+    golden_vectors = preloaded_models[model_name].encode(
+        golden, normalize_embeddings=True
+    )
+    generated_vectors = preloaded_models[model_name].encode(
+        generated, normalize_embeddings=True
+    )
     similarities = generated_vectors @ golden_vectors.T
     return similarities

--- a/dialogue2graph/pipelines/core/__init__.py
+++ b/dialogue2graph/pipelines/core/__init__.py
@@ -1,2 +1,4 @@
 from dialogue2graph.pipelines.core.dialogue_sampling import RecursiveDialogueSampler
 from dialogue2graph.pipelines.core.pipeline import BasePipeline
+
+__all__ = ["RecursiveDialogueSampler", "BasePipeline"]

--- a/dialogue2graph/pipelines/core/algorithms.py
+++ b/dialogue2graph/pipelines/core/algorithms.py
@@ -23,7 +23,9 @@ class BaseAlgorithm(BaseModel, abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def evaluate(self, *args, report_type: Literal["dict", "dataframe"] = "dict", **kwargs) -> Union[dict, DataFrame]:
+    def evaluate(
+        self, *args, report_type: Literal["dict", "dataframe"] = "dict", **kwargs
+    ) -> Union[dict, DataFrame]:
         raise NotImplementedError
 
 
@@ -42,7 +44,9 @@ class DialogueGenerator(BaseAlgorithm):
     def __init__(self):
         super().__init__()
 
-    def invoke(self, graph: BaseGraph, start_node: int = 1, end_node: int = 0, topic: str = "") -> List[Dialogue]:
+    def invoke(
+        self, graph: BaseGraph, start_node: int = 1, end_node: int = 0, topic: str = ""
+    ) -> List[Dialogue]:
         raise NotImplementedError
 
 

--- a/dialogue2graph/pipelines/core/dialogue.py
+++ b/dialogue2graph/pipelines/core/dialogue.py
@@ -24,9 +24,13 @@ class Dialogue(BaseModel):
     """
 
     messages: List[DialogueMessage] = Field(default_factory=list)
-    id: str = Field(default=str(uuid.uuid1()), description="Unique identifier for the dialogue")
+    id: str = Field(
+        default=str(uuid.uuid1()), description="Unique identifier for the dialogue"
+    )
     topic: str = ""
-    validate: bool = Field(default=True, description="Whether to validate messages upon initialization")
+    validate: bool = Field(
+        default=True, description="Whether to validate messages upon initialization"
+    )
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -49,12 +53,15 @@ class Dialogue(BaseModel):
             Dialogue object with parsed messages
         """
         messages: List[DialogueMessage] = [
-            DialogueMessage(participant=line.split("\t")[0], text=line.split("\t")[1]) for line in string.strip().split("\n")
+            DialogueMessage(participant=line.split("\t")[0], text=line.split("\t")[1])
+            for line in string.strip().split("\n")
         ]
         return cls(messages=messages)
 
     @classmethod
-    def from_list(cls, messages: List[Dict[str, str]], id: str = "", validate: bool = True) -> "Dialogue":
+    def from_list(
+        cls, messages: List[Dict[str, str]], id: str = "", validate: bool = True
+    ) -> "Dialogue":
         """Create a Dialogue from a list of dictionaries."""
         dialogue_messages = [DialogueMessage(**m) for m in messages]
         return cls(messages=dialogue_messages, id=id, validate=validate)
@@ -65,13 +72,32 @@ class Dialogue(BaseModel):
         nodes_attributes = nx.get_node_attributes(graph.graph, "utterances")
         edges_attributes = nx.get_edge_attributes(graph.graph, "utterances")
         for node in range(len(node_list)):
-            utts.append({"participant": "assistant", "text": nodes_attributes[node_list[node]][0]})
+            utts.append(
+                {
+                    "participant": "assistant",
+                    "text": nodes_attributes[node_list[node]][0],
+                }
+            )
             if node == len(node_list) - 1:
                 if graph.graph.has_edge(node_list[node], node_list[0]):
-                    utts.append({"participant": "user", "text": edges_attributes[(node_list[node], node_list[0])][0]})
+                    utts.append(
+                        {
+                            "participant": "user",
+                            "text": edges_attributes[(node_list[node], node_list[0])][
+                                0
+                            ],
+                        }
+                    )
             else:
                 if graph.graph.has_edge(node_list[node], node_list[node + 1]):
-                    utts.append({"participant": "user", "text": edges_attributes[(node_list[node], node_list[node + 1])][0]})
+                    utts.append(
+                        {
+                            "participant": "user",
+                            "text": edges_attributes[
+                                (node_list[node], node_list[node + 1])
+                            ][0],
+                        }
+                    )
 
         return cls(messages=utts, validate=validate)
 
@@ -81,7 +107,9 @@ class Dialogue(BaseModel):
 
     def __str__(self) -> str:
         """Returns a readable string representation of the dialogue."""
-        return "\n".join(f"{msg.participant}: {msg.text}" for msg in self.messages).strip()
+        return "\n".join(
+            f"{msg.participant}: {msg.text}" for msg in self.messages
+        ).strip()
 
     def append(self, text: str, participant: str) -> None:
         """Adds a new message to the dialogue.
@@ -98,7 +126,10 @@ class Dialogue(BaseModel):
         Args:
             messages: List of DialogueMessage objects or dicts to add
         """
-        new_messages = [msg if isinstance(msg, DialogueMessage) else DialogueMessage(**msg) for msg in messages]
+        new_messages = [
+            msg if isinstance(msg, DialogueMessage) else DialogueMessage(**msg)
+            for msg in messages
+        ]
         self.__validate(new_messages)
         self.messages.extend(new_messages)
 
@@ -109,9 +140,13 @@ class Dialogue(BaseModel):
 
         # Check if first message is from assistant
         if messages[0].participant != "assistant":
-            raise ValueError(f"First message must be from assistant, got: {messages[0]}")
+            raise ValueError(
+                f"First message must be from assistant, got: {messages[0]}"
+            )
 
         # Check for consecutive messages from same participant
         for i in range(len(messages) - 1):
             if messages[i].participant == messages[i + 1].participant:
-                raise ValueError(f"Cannot have consecutive messages from the same participant. Messages: {messages[i]}, {messages[i + 1]}")
+                raise ValueError(
+                    f"Cannot have consecutive messages from the same participant. Messages: {messages[i]}, {messages[i + 1]}"
+                )

--- a/dialogue2graph/pipelines/core/dialogue_sampling.py
+++ b/dialogue2graph/pipelines/core/dialogue_sampling.py
@@ -17,7 +17,9 @@ class EnvSettings(BaseSettings, case_sensitive=True):
     """Pydantic settings to get env variables"""
 
     model_config = SettingsConfigDict(
-        env_file=os.environ.get("PATH_TO_ENV", ".env"), env_file_encoding="utf-8", env_file_exists_ok=False  # Makes .env file optional
+        env_file=os.environ.get("PATH_TO_ENV", ".env"),
+        env_file_encoding="utf-8",
+        env_file_exists_ok=False,  # Makes .env file optional
     )
     OPENAI_API_KEY: Optional[str] = None
     OPENAI_BASE_URL: Optional[str] = None
@@ -36,7 +38,9 @@ except Exception:
 class RecursiveDialogueSampler(DialogueGenerator):
     """Recursive dialogue sampler for the graph"""
 
-    def invoke(self, graph: BaseGraph, upper_limit: int, model_name: str = "o1-mini", temp=1) -> list[Dialogue]:
+    def invoke(
+        self, graph: BaseGraph, upper_limit: int, model_name: str = "o1-mini", temp=1
+    ) -> list[Dialogue]:
         """Finds all the dialogues in the graph
         upper_limit is used to limit repeats used in graph.all_paths method
         model_name is LLM to find cycling nodes when list of finishing nodes is empty
@@ -49,7 +53,12 @@ class RecursiveDialogueSampler(DialogueGenerator):
         if not finished_nodes:
             cycle_nodes = find_graph_ends(
                 graph,
-                model=ChatOpenAI(model=model_name, api_key=env_settings.OPENAI_API_KEY, base_url=env_settings.OPENAI_BASE_URL, temperature=temp),
+                model=ChatOpenAI(
+                    model=model_name,
+                    api_key=env_settings.OPENAI_API_KEY,
+                    base_url=env_settings.OPENAI_BASE_URL,
+                    temperature=temp,
+                ),
             )["value"]
         finished_nodes = mix_ends(graph, finished_nodes, cycle_nodes)
         while repeats <= upper_limit:
@@ -65,7 +74,13 @@ class RecursiveDialogueSampler(DialogueGenerator):
     async def ainvoke(self, *args, **kwargs):
         return self.invoke(*args, **kwargs)
 
-    async def evaluate(self, graph, upper_limit, target_dialogues, report_type=Literal["dict", "dataframe"]):
+    async def evaluate(
+        self,
+        graph,
+        upper_limit,
+        target_dialogues,
+        report_type=Literal["dict", "dataframe"],
+    ):
         dialogues = self.invoke(graph, upper_limit)
         report = {
             "all_utterances_present": [match_triplets_dg(graph, dialogues)].value,
@@ -107,7 +122,12 @@ def all_combinations(path: list, start: dict, next: int, visited: list):
     if next < len(path):
         # print("MAX: ", max_v)
         for utt in path[next]["text"]:
-            all_combinations(path, {"participant": path[next]["participant"], "text": utt}, next + 1, visited.copy())
+            all_combinations(
+                path,
+                {"participant": path[next]["participant"], "text": utt},
+                next + 1,
+                visited.copy(),
+            )
     else:
         counter += 1
         if counter == env_settings.SAMPLING_MAX:
@@ -162,7 +182,16 @@ def dialogue_triplets(seq: list[list[dict]]) -> set[tuple[str]]:
     for dialogue in seq:
         assist_texts = [d["text"] for d in dialogue if d["participant"] == "assistant"]
         user_texts = [d["text"] for d in dialogue if d["participant"] == "user"]
-        res.extend([(a1, u, a2) for a1, u, a2 in zip(assist_texts[:-1], user_texts[: len(assist_texts) - 1], assist_texts[1:])])
+        res.extend(
+            [
+                (a1, u, a2)
+                for a1, u, a2 in zip(
+                    assist_texts[:-1],
+                    user_texts[: len(assist_texts) - 1],
+                    assist_texts[1:],
+                )
+            ]
+        )
     return set(res)
 
 
@@ -170,7 +199,9 @@ def remove_duplicated_dialogues(seq: list[list[dict]]) -> list[list[dict]]:
     """Removes duplicated dialogues from list of dialogues seq"""
     single_seq = [seq[0]]
     for s in seq[1:]:
-        if not dialogue_doublets([s]).issubset(dialogue_doublets(single_seq)) or not dialogue_triplets([s]).issubset(dialogue_triplets(single_seq)):
+        if not dialogue_doublets([s]).issubset(
+            dialogue_doublets(single_seq)
+        ) or not dialogue_triplets([s]).issubset(dialogue_triplets(single_seq)):
             single_seq.append(s)
     return single_seq
 
@@ -199,12 +230,16 @@ def get_dialogues(graph: BaseGraph, repeats: int, ends: list[int]) -> list[Dialo
     for p in node_paths:
         path = []
         for idx, s in enumerate(p[:-1]):
-            path.append({"text": graph.node_by_id(s)["utterances"], "participant": "assistant"})
+            path.append(
+                {"text": graph.node_by_id(s)["utterances"], "participant": "assistant"}
+            )
             sources = graph.edge_by_source(s)
             targets = graph.edge_by_target(p[idx + 1])
             edge = [e for e in sources if e in targets][0]
             path.append(({"text": edge["utterances"], "participant": "user"}))
-        path.append({"text": graph.node_by_id(p[-1])["utterances"], "participant": "assistant"})
+        path.append(
+            {"text": graph.node_by_id(p[-1])["utterances"], "participant": "assistant"}
+        )
         full_paths.append(path)
     dialogues = []
     for f in full_paths:

--- a/dialogue2graph/pipelines/core/graph.py
+++ b/dialogue2graph/pipelines/core/graph.py
@@ -70,7 +70,6 @@ class BaseGraph(BaseModel, abc.ABC):
 
 
 class Graph(BaseGraph):
-
     def __init__(self, graph_dict: dict, **kwargs: Any):
         # Pass graph_dict to the parent class
         super().__init__(graph_dict=graph_dict, **kwargs)
@@ -93,7 +92,6 @@ class Graph(BaseGraph):
                     if len(left) == 0:
                         return True
         if len(left):
-
             return False
         return True
 
@@ -116,14 +114,29 @@ class Graph(BaseGraph):
             theme = node.get("theme")
             label = node.get("label")
             if type(node["utterances"]) is list:
-                self.graph.add_node(cur_node_id, theme=theme, label=label, utterances=node["utterances"])
+                self.graph.add_node(
+                    cur_node_id, theme=theme, label=label, utterances=node["utterances"]
+                )
             else:
-                self.graph.add_node(cur_node_id, theme=theme, label=label, utterances=[node["utterances"]])
+                self.graph.add_node(
+                    cur_node_id,
+                    theme=theme,
+                    label=label,
+                    utterances=[node["utterances"]],
+                )
 
         for link in self.graph_dict["edges"]:
             source = self.node_mapping.get(link["source"], link["source"])
             target = self.node_mapping.get(link["target"], link["target"])
-            self.graph.add_edges_from([(source, target, {"theme": link.get("theme"), "utterances": link["utterances"]})])
+            self.graph.add_edges_from(
+                [
+                    (
+                        source,
+                        target,
+                        {"theme": link.get("theme"), "utterances": link["utterances"]},
+                    )
+                ]
+            )
 
     def visualise(self, *args, **kwargs):
         plt.figure(figsize=(17, 11))  # Make the plot bigger
@@ -131,11 +144,23 @@ class Graph(BaseGraph):
             pos = nx.nx_agraph.pygraphviz_layout(self.graph)
         except ImportError as e:
             pos = nx.kamada_kawai_layout(self.graph)
-            logger.warning(f"{e}.\nInstall pygraphviz from http://pygraphviz.github.io/ .\nFalling back to default layout.")
-        nx.draw(self.graph, pos, with_labels=False, node_color="lightblue", node_size=500, font_size=8, arrows=True)
+            logger.warning(
+                f"{e}.\nInstall pygraphviz from http://pygraphviz.github.io/ .\nFalling back to default layout."
+            )
+        nx.draw(
+            self.graph,
+            pos,
+            with_labels=False,
+            node_color="lightblue",
+            node_size=500,
+            font_size=8,
+            arrows=True,
+        )
         edge_labels = nx.get_edge_attributes(self.graph, "utterances")
         node_labels = nx.get_node_attributes(self.graph, "utterances")
-        nx.draw_networkx_edge_labels(self.graph, pos, edge_labels=edge_labels, font_size=12)
+        nx.draw_networkx_edge_labels(
+            self.graph, pos, edge_labels=edge_labels, font_size=12
+        )
         nx.draw_networkx_labels(self.graph, pos, labels=node_labels, font_size=10)
 
         plt.title(__name__)
@@ -147,15 +172,33 @@ class Graph(BaseGraph):
             pos = nx.nx_agraph.pygraphviz_layout(self.graph)
         except ImportError as e:
             pos = nx.kamada_kawai_layout(self.graph)
-            logger.warning(f"{e}.\nInstall pygraphviz from http://pygraphviz.github.io/ .\nFalling back to default layout.")
-        nx.draw(self.graph, pos, with_labels=False, node_color="lightblue", node_size=500, font_size=8, arrows=True)
-        edge_attrs = {(e["source"], e["target"]): len(e["utterances"]) for e in self.graph_dict["edges"]}
-        node_attrs = {n["id"]: f"{n['id']}:{len(n['utterances'])}" for n in self.graph_dict["nodes"]}
+            logger.warning(
+                f"{e}.\nInstall pygraphviz from http://pygraphviz.github.io/ .\nFalling back to default layout."
+            )
+        nx.draw(
+            self.graph,
+            pos,
+            with_labels=False,
+            node_color="lightblue",
+            node_size=500,
+            font_size=8,
+            arrows=True,
+        )
+        edge_attrs = {
+            (e["source"], e["target"]): len(e["utterances"])
+            for e in self.graph_dict["edges"]
+        }
+        node_attrs = {
+            n["id"]: f"{n['id']}:{len(n['utterances'])}"
+            for n in self.graph_dict["nodes"]
+        }
         nx.set_edge_attributes(self.graph, edge_attrs, "attrs")
         nx.set_node_attributes(self.graph, node_attrs, "attrs")
         edge_labels = nx.get_edge_attributes(self.graph, "attrs")
         node_labels = nx.get_node_attributes(self.graph, "attrs")
-        nx.draw_networkx_edge_labels(self.graph, pos, edge_labels=edge_labels, font_size=12)
+        nx.draw_networkx_edge_labels(
+            self.graph, pos, edge_labels=edge_labels, font_size=12
+        )
         nx.draw_networkx_labels(self.graph, pos, labels=node_labels, font_size=10)
 
         plt.title(name)
@@ -163,10 +206,14 @@ class Graph(BaseGraph):
         plt.show()
 
     def nodes_by_utterance(self, utterance: str) -> list[dict]:
-        return [node for node in self.graph_dict["nodes"] if utterance in node["utterances"]]
+        return [
+            node for node in self.graph_dict["nodes"] if utterance in node["utterances"]
+        ]
 
     def edges_by_utterance(self, utterance: str) -> list[dict]:
-        return [edge for edge in self.graph_dict["edges"] if utterance in edge["utterances"]]
+        return [
+            edge for edge in self.graph_dict["edges"] if utterance in edge["utterances"]
+        ]
 
     def node_by_id(self, id: int):
         for node in self.graph_dict["nodes"]:
@@ -198,7 +245,9 @@ class Graph(BaseGraph):
         node_non_starts = set([n["id"] for n in graph["nodes"] if not n["is_start"]])
         edge_targets = set([e["target"] for e in graph["edges"]])
         edge_sources = set([e["source"] for e in graph["edges"]])
-        return node_ids == edge_targets.union(edge_sources) and node_non_starts.issubset(edge_targets)
+        return node_ids == edge_targets.union(
+            edge_sources
+        ) and node_non_starts.issubset(edge_targets)
 
     def remove_duplicated_edges(self):
         graph = self.graph_dict
@@ -214,7 +263,11 @@ class Graph(BaseGraph):
                 new_edge["utterances"].extend(e["utterances"])
             new_edge["utterances"] = list(set(new_edge["utterances"]))
             new_edges.append(new_edge)
-        self.graph_dict = {"edges": [e for e in edges if (e["source"], e["target"]) not in duplicates] + new_edges, "nodes": graph["nodes"]}
+        self.graph_dict = {
+            "edges": [e for e in edges if (e["source"], e["target"]) not in duplicates]
+            + new_edges,
+            "nodes": graph["nodes"],
+        }
         return Graph(self.graph_dict)
 
     def remove_duplicated_nodes(self):
@@ -241,7 +294,10 @@ class Graph(BaseGraph):
                         edges[idx]["source"] = doubled
                     if e["target"] == n["id"]:
                         edges[idx]["target"] = doubled
-        self.graph_dict = {"edges": edges, "nodes": [n for n in nodes if n["id"] not in to_remove]}
+        self.graph_dict = {
+            "edges": edges,
+            "nodes": [n for n in nodes if n["id"] not in to_remove],
+        }
         return self.remove_duplicated_edges()
 
     def all_paths(self, start: int, visited: list[int], repeats: int):
@@ -249,7 +305,9 @@ class Graph(BaseGraph):
         where node with id=start added to last repeats elements in the visited path do not have any occurance
         visited_list is global variable to store the result"""
         global visited_list
-        if len(visited) < repeats or not self._list_in(visited[-repeats:] + [start], visited):
+        if len(visited) < repeats or not self._list_in(
+            visited[-repeats:] + [start], visited
+        ):
             visited.append(start)
             for edge in self.edge_by_source(start):
                 self.all_paths(edge["target"], visited.copy(), repeats)

--- a/dialogue2graph/pipelines/core/pipeline.py
+++ b/dialogue2graph/pipelines/core/pipeline.py
@@ -1,10 +1,24 @@
 from typing import Union
 from pydantic import BaseModel, Field
-from dialogue2graph.pipelines.core.algorithms import DialogAugmentation, DialogueGenerator, GraphGenerator, GraphExtender, InputParser
+from dialogue2graph.pipelines.core.algorithms import (
+    DialogAugmentation,
+    DialogueGenerator,
+    GraphGenerator,
+    GraphExtender,
+    InputParser,
+)
 
 
 class BasePipeline(BaseModel):
-    steps: list[Union[InputParser, DialogueGenerator, DialogAugmentation, GraphGenerator, GraphExtender]] = Field(default_factory=list)
+    steps: list[
+        Union[
+            InputParser,
+            DialogueGenerator,
+            DialogAugmentation,
+            GraphGenerator,
+            GraphExtender,
+        ]
+    ] = Field(default_factory=list)
 
     def _validate_pipeline(self):
         pass

--- a/dialogue2graph/pipelines/core/schemas.py
+++ b/dialogue2graph/pipelines/core/schemas.py
@@ -6,14 +6,18 @@ from dialogue2graph.pipelines.core.dialogue import Dialogue
 class Edge(BaseModel):
     source: int = Field(description="ID of the source node")
     target: int = Field(description="ID of the target node")
-    utterances: List[str] = Field(description="User's utterances that trigger this transition")
+    utterances: List[str] = Field(
+        description="User's utterances that trigger this transition"
+    )
 
 
 class Node(BaseModel):
     id: int = Field(description="Unique identifier for the node")
     label: str = Field(description="Label describing the node's purpose")
     is_start: bool = Field(description="Whether this is the starting node")
-    utterances: List[str] = Field(description="Possible assistant responses at this node")
+    utterances: List[str] = Field(
+        description="Possible assistant responses at this node"
+    )
 
 
 class DialogueGraph(BaseModel):

--- a/dialogue2graph/pipelines/d2g_algo/group_nodes/__init__.py
+++ b/dialogue2graph/pipelines/d2g_algo/group_nodes/__init__.py
@@ -1,1 +1,1 @@
-from .group_nodes import group_nodes
+from .group_nodes import group_nodes as group_nodes

--- a/dialogue2graph/pipelines/d2g_algo/group_nodes/group_nodes.py
+++ b/dialogue2graph/pipelines/d2g_algo/group_nodes/group_nodes.py
@@ -3,7 +3,6 @@ from dialogue2graph.pipelines.core.dialogue import Dialogue
 
 
 def _get_cross(search, list2):
-
     sublist = [p for p in list2 if search in p]
     to_add = []
     for s in sublist:
@@ -57,7 +56,6 @@ def _get_indices(lst, element):
 
 
 def _get_tails(dialogue: Dialogue, assistant: list, node: str):
-
     ids = _get_indices(assistant, node)
     tails = []
     for id in ids:
@@ -92,8 +90,9 @@ def group_nodes(dialogues: list[Dialogue], nodes_list: list[str]) -> list[list[s
 
     for ind1, node1 in enumerate(nodes_list):
         cur_nodes_list = nodes_list[ind1 + 1 :]
-        for ind2, node2 in zip(range(ind1 + 1, ind1 + 1 + len(cur_nodes_list)), cur_nodes_list):
-
+        for ind2, node2 in zip(
+            range(ind1 + 1, ind1 + 1 + len(cur_nodes_list)), cur_nodes_list
+        ):
             tail_cond = _compare_tails(dialogues, node1, node2)
             if tail_cond:
                 pairs.append((ind1, ind2))

--- a/dialogue2graph/pipelines/d2g_algo/pipeline.py
+++ b/dialogue2graph/pipelines/d2g_algo/pipeline.py
@@ -20,15 +20,32 @@ class Pipeline(BasePipeline):
         # check if models are in model storage
         # if model is not in model storage put the default model there
         if filling_llm not in model_storage.storage:
-            model_storage.add(key=filling_llm, config={"name": "gpt-4o-latest", "temperature": 0}, model_type="llm")
+            model_storage.add(
+                key=filling_llm,
+                config={"name": "gpt-4o-latest", "temperature": 0},
+                model_type="llm",
+            )
 
         if formatting_llm not in model_storage.storage:
-            model_storage.add(key=formatting_llm, config={"name": "gpt-4o-mini", "temperature": 0}, model_type="llm")
+            model_storage.add(
+                key=formatting_llm,
+                config={"name": "gpt-4o-mini", "temperature": 0},
+                model_type="llm",
+            )
 
         if sim_model not in model_storage.storage:
-            model_storage.add(key=sim_model, config={"model_name": "cointegrated/LaBSE-en-ru", "device": "cpu"}, model_type="emb")
+            model_storage.add(
+                key=sim_model,
+                config={"model_name": "cointegrated/LaBSE-en-ru", "device": "cpu"},
+                model_type="emb",
+            )
 
-        super().__init__(steps=[DataParser(), AlgoGenerator(model_storage, filling_llm, formatting_llm, sim_model)])
+        super().__init__(
+            steps=[
+                DataParser(),
+                AlgoGenerator(model_storage, filling_llm, formatting_llm, sim_model),
+            ]
+        )
 
     def _validate_pipeline(self):
         pass

--- a/dialogue2graph/pipelines/d2g_extender/pipeline.py
+++ b/dialogue2graph/pipelines/d2g_extender/pipeline.py
@@ -2,7 +2,9 @@ from dotenv import load_dotenv
 from dialogue2graph.pipelines.core.pipeline import BasePipeline
 from dialogue2graph.pipelines.core.dialogue import Dialogue
 from dialogue2graph.pipelines.core.graph import Graph
-from dialogue2graph.pipelines.d2g_algo.three_stages_algo import ThreeStagesGraphGenerator as AlgoGenerator
+from dialogue2graph.pipelines.d2g_algo.three_stages_algo import (
+    ThreeStagesGraphGenerator as AlgoGenerator,
+)
 from dialogue2graph.pipelines.model_storage import ModelStorage
 from .three_stages_extender import ThreeStagesGraphGenerator as Extender
 from dialogue2graph.pipelines.helpers.parse_data import DataParser
@@ -24,29 +26,49 @@ class Pipeline(BasePipeline):
         # check if models are in model storage
         # if model is not in model storage put the default model there
         if extending_llm not in model_storage.storage:
-            model_storage.add(key=extending_llm, config={"name": "gpt-4o-latest", "temperature": 0}, model_type="llm")
+            model_storage.add(
+                key=extending_llm,
+                config={"name": "gpt-4o-latest", "temperature": 0},
+                model_type="llm",
+            )
 
         if filling_llm not in model_storage.storage:
-            model_storage.add(key=filling_llm, config={"name": "o3-mini", "temperature": 1}, model_type="llm")
+            model_storage.add(
+                key=filling_llm,
+                config={"name": "o3-mini", "temperature": 1},
+                model_type="llm",
+            )
 
         if formatting_llm not in model_storage.storage:
-            model_storage.add(key=formatting_llm, config={"name": "gpt-4o-mini", "temperature": 0}, model_type="llm")
+            model_storage.add(
+                key=formatting_llm,
+                config={"name": "gpt-4o-mini", "temperature": 0},
+                model_type="llm",
+            )
 
         if sim_model not in model_storage.storage:
-            model_storage.add(key=sim_model, config={"model_name": "cointegrated/LaBSE-en-ru", "device": "cpu"}, model_type="emb")
+            model_storage.add(
+                key=sim_model,
+                config={"model_name": "cointegrated/LaBSE-en-ru", "device": "cpu"},
+                model_type="emb",
+            )
 
         super().__init__(
             steps=[
                 DataParser(),
                 AlgoGenerator(model_storage, filling_llm, formatting_llm, sim_model),
-                Extender(model_storage, extending_llm, filling_llm, formatting_llm, sim_model),
+                Extender(
+                    model_storage, extending_llm, filling_llm, formatting_llm, sim_model
+                ),
             ]
         )
 
     def _validate_pipeline(self):
         pass
 
-    def invoke(self, data: Dialogue | list[Dialogue] | dict | list[list] | list[dict]) -> Graph:
+    def invoke(
+        self, data: Dialogue | list[Dialogue] | dict | list[list] | list[dict]
+    ) -> Graph:
         dialogues = self.steps[0].invoke(data)
         graph = self.steps[1].invoke(dialogues[:1])
         for idx in range(1, len(dialogues)):

--- a/dialogue2graph/pipelines/d2g_llm/pipeline.py
+++ b/dialogue2graph/pipelines/d2g_llm/pipeline.py
@@ -18,23 +18,45 @@ class Pipeline(BasePipeline):
         formatting_llm: str = "d2g_llm_formatting_llm:v1",
         sim_model: str = "d2g_llm_sim_model:v1",
     ):
-
         # check if models are in model storage
         # if model is not in model storage put the default model there
         if grouping_llm not in model_storage.storage:
-            model_storage.add(key=grouping_llm, config={"name": "gpt-4o-latest", "temperature": 0}, model_type="llm")
+            model_storage.add(
+                key=grouping_llm,
+                config={"name": "gpt-4o-latest", "temperature": 0},
+                model_type="llm",
+            )
             # grouping_llm = model_storage.storage["d2g_llm_grouping_llm:v1"].model
 
         if filling_llm not in model_storage.storage:
-            model_storage.add(key=filling_llm, config={"name": "o3-mini", "temperature": 1}, model_type="llm")
+            model_storage.add(
+                key=filling_llm,
+                config={"name": "o3-mini", "temperature": 1},
+                model_type="llm",
+            )
 
         if formatting_llm not in model_storage.storage:
-            model_storage.add(key=formatting_llm, config={"name": "gpt-4o-mini", "temperature": 0}, model_type="llm")
+            model_storage.add(
+                key=formatting_llm,
+                config={"name": "gpt-4o-mini", "temperature": 0},
+                model_type="llm",
+            )
 
         if sim_model not in model_storage.storage:
-            model_storage.add(key=sim_model, config={"model_name": "cointegrated/LaBSE-en-ru", "device": "cpu"}, model_type="emb")
+            model_storage.add(
+                key=sim_model,
+                config={"model_name": "cointegrated/LaBSE-en-ru", "device": "cpu"},
+                model_type="emb",
+            )
 
-        super().__init__(steps=[DataParser(), LLMGenerator(model_storage, grouping_llm, filling_llm, formatting_llm, sim_model)])
+        super().__init__(
+            steps=[
+                DataParser(),
+                LLMGenerator(
+                    model_storage, grouping_llm, filling_llm, formatting_llm, sim_model
+                ),
+            ]
+        )
 
     def _validate_pipeline(self):
         pass

--- a/dialogue2graph/pipelines/d2g_llm/prompts.py
+++ b/dialogue2graph/pipelines/d2g_llm/prompts.py
@@ -37,7 +37,11 @@ List of dialogues: """
 
 graph_example_1 = {
     "edges": [
-        {"source": 1, "target": 2, "utterances": ["I need to make an order", "I want to order from you"]},
+        {
+            "source": 1,
+            "target": 2,
+            "utterances": ["I need to make an order", "I want to order from you"],
+        },
         {
             "source": 2,
             "target": 3,
@@ -50,19 +54,34 @@ graph_example_1 = {
         {"source": 4, "target": 2, "utterances": ["Start new order"]},
     ],
     "nodes": [
-        {"id": 1, "label": "start", "is_start": True, "utterances": ["How can I help?", "Hello"]},
-        {"id": 2, "label": "ask_books", "is_start": False, "utterances": ["What books do you like?"]},
+        {
+            "id": 1,
+            "label": "start",
+            "is_start": True,
+            "utterances": ["How can I help?", "Hello"],
+        },
+        {
+            "id": 2,
+            "label": "ask_books",
+            "is_start": False,
+            "utterances": ["What books do you like?"],
+        },
         {
             "id": 3,
             "label": "ask_payment_method",
             "is_start": False,
-            "utterances": ["Please, enter the payment method you would like to use: cash or credit card.", "How would you prefer to pay?"],
+            "utterances": [
+                "Please, enter the payment method you would like to use: cash or credit card.",
+                "How would you prefer to pay?",
+            ],
         },
         {
             "id": 4,
             "label": "ask_to_redo",
             "is_start": False,
-            "utterances": ["Something is wrong, can you please use other payment method or start order again"],
+            "utterances": [
+                "Something is wrong, can you please use other payment method or start order again"
+            ],
         },
     ],
     "reason": "",

--- a/dialogue2graph/pipelines/d2g_llm/three_stages_llm.py
+++ b/dialogue2graph/pipelines/d2g_llm/three_stages_llm.py
@@ -15,7 +15,10 @@ from dialogue2graph.metrics.llm_metrics import compare_graphs
 from dialogue2graph.metrics.no_llm_metrics import is_same_structure
 
 from dialogue2graph.utils.dg_helper import connect_nodes, get_helpers
-from dialogue2graph.pipelines.helpers.prompts.missing_edges_prompt import add_edge_prompt_1, add_edge_prompt_2
+from dialogue2graph.pipelines.helpers.prompts.missing_edges_prompt import (
+    add_edge_prompt_1,
+    add_edge_prompt_2,
+)
 from .prompts import graph_example_1, grouping_prompt_1, grouping_prompt_2
 
 
@@ -36,12 +39,21 @@ class ThreeStagesGraphGenerator(GraphGenerator):
     """
 
     model_storage: ModelStorage = Field(description="Model storage")
-    grouping_llm: str = Field(description="LLM for grouping assistant utterances into nodes")
+    grouping_llm: str = Field(
+        description="LLM for grouping assistant utterances into nodes"
+    )
     filling_llm: str = Field(description="LLM for adding missing edges")
     formatting_llm: str = Field(description="LLM for formatting output")
     sim_model: str = Field(description="Similarity model")
 
-    def __init__(self, model_storage: ModelStorage, grouping_llm: str, filling_llm: str, formatting_llm: str, sim_model: str):
+    def __init__(
+        self,
+        model_storage: ModelStorage,
+        grouping_llm: str,
+        filling_llm: str,
+        formatting_llm: str,
+        sim_model: str,
+    ):
         # if grouping_llm not in model_storage.storage:
         #     model_storage.add(key="d2g_llm_grouping_llm:v1", config={"name": "gpt-4o-latest", "temperature": 0}, model_type="llm")
         #     grouping_llm = "d2g_llm_grouping_llm:v1"
@@ -59,11 +71,16 @@ class ThreeStagesGraphGenerator(GraphGenerator):
         #     sim_model = "d2g_llm_sim_model:v1"
 
         super().__init__(
-            model_storage=model_storage, grouping_llm=grouping_llm, filling_llm=filling_llm, formatting_llm=formatting_llm, sim_model=sim_model
+            model_storage=model_storage,
+            grouping_llm=grouping_llm,
+            filling_llm=filling_llm,
+            formatting_llm=formatting_llm,
+            sim_model=sim_model,
         )
 
-    def invoke(self, dialogue: list[Dialogue] = None, graph: DialogueGraph = None) -> BaseGraph:
-
+    def invoke(
+        self, dialogue: list[Dialogue] = None, graph: DialogueGraph = None
+    ) -> BaseGraph:
         partial_variables = {}
         prompt_extra = grouping_prompt_2
         for idx, dial in enumerate(dialogue):
@@ -76,21 +93,34 @@ class ThreeStagesGraphGenerator(GraphGenerator):
         )
 
         fixed_output_parser = OutputFixingParser.from_llm(
-            parser=PydanticOutputParser(pydantic_object=DialogueNodes), llm=self.model_storage.storage[self.formatting_llm].model
+            parser=PydanticOutputParser(pydantic_object=DialogueNodes),
+            llm=self.model_storage.storage[self.formatting_llm].model,
         )
-        chain = self.model_storage.storage[self.grouping_llm].model | fixed_output_parser
+        chain = (
+            self.model_storage.storage[self.grouping_llm].model | fixed_output_parser
+        )
 
-        messages = [HumanMessage(content=prompt.format(graph_example_1=graph_example_1))]
+        messages = [
+            HumanMessage(content=prompt.format(graph_example_1=graph_example_1))
+        ]
         nodes = chain.invoke(messages).model_dump()
 
         _, _, last_user = get_helpers(dialogue)
 
         try:
-            graph_dict = connect_nodes(nodes["nodes"], dialogue, self.model_storage.storage[self.sim_model].model)
+            graph_dict = connect_nodes(
+                nodes["nodes"],
+                dialogue,
+                self.model_storage.storage[self.sim_model].model,
+            )
         except Exception as e:
             print(e)
             return Graph({})
-        graph_dict = {"nodes": graph_dict["nodes"], "edges": graph_dict["edges"], "reason": ""}
+        graph_dict = {
+            "nodes": graph_dict["nodes"],
+            "edges": graph_dict["edges"],
+            "reason": "",
+        }
 
         try:
             if not last_user:
@@ -103,7 +133,10 @@ class ThreeStagesGraphGenerator(GraphGenerator):
                 partial_variables[f"var_{idx}"] = dial.to_list()
                 prompt_extra += f" Dialogue_{idx}: {{var_{idx}}}"
             prompt = PromptTemplate(
-                template=add_edge_prompt_1 + "{graph_dict}. " + add_edge_prompt_2 + prompt_extra,
+                template=add_edge_prompt_1
+                + "{graph_dict}. "
+                + add_edge_prompt_2
+                + prompt_extra,
                 input_variables=["graph_dict"],
                 partial_variables=partial_variables,
             )
@@ -111,9 +144,12 @@ class ThreeStagesGraphGenerator(GraphGenerator):
             print("PROMPT: ", prompt)
 
             fixed_output_parser = OutputFixingParser.from_llm(
-                parser=PydanticOutputParser(pydantic_object=DialogueGraph), llm=self.model_storage.storage[self.formatting_llm].model
+                parser=PydanticOutputParser(pydantic_object=DialogueGraph),
+                llm=self.model_storage.storage[self.formatting_llm].model,
             )
-            chain = self.model_storage.storage[self.filling_llm].model | fixed_output_parser
+            chain = (
+                self.model_storage.storage[self.filling_llm].model | fixed_output_parser
+            )
 
             messages = [HumanMessage(content=prompt.format(graph_dict=graph_dict))]
 

--- a/dialogue2graph/pipelines/helpers/parse_data.py
+++ b/dialogue2graph/pipelines/helpers/parse_data.py
@@ -12,8 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 class DataParser(InputParser):
-
-    def invoke(self, data: Dialogue | list[Dialogue] | dict | list[list] | list[dict] | str) -> List[Dialogue]:
+    def invoke(
+        self, data: Dialogue | list[Dialogue] | dict | list[list] | list[dict] | str
+    ) -> List[Dialogue]:
         """Validate and convert user's data into list of Dialogue
         Input data can be as follows:
         [{'participant': user or assistant, 'text': text}]
@@ -25,9 +26,13 @@ class DataParser(InputParser):
         """
 
         try:
-            validation = TypeAdapter(Dialogue | List[DialogueMessage] | List[List[DialogueMessage]] | PosixPath | List[Dialogue]).validate_python(
-                data
-            )
+            validation = TypeAdapter(
+                Dialogue
+                | List[DialogueMessage]
+                | List[List[DialogueMessage]]
+                | PosixPath
+                | List[Dialogue]
+            ).validate_python(data)
         except ValidationError as e:
             logger.error(f"Input data validation error: {e}")
             return []
@@ -37,7 +42,12 @@ class DataParser(InputParser):
                 if isinstance(dialogues, dict):
                     dialogues = [dialogues]
             try:
-                validation = TypeAdapter(Dialogue | List[DialogueMessage] | List[List[DialogueMessage]] | List[Dialogue]).validate_python(dialogues)
+                validation = TypeAdapter(
+                    Dialogue
+                    | List[DialogueMessage]
+                    | List[List[DialogueMessage]]
+                    | List[Dialogue]
+                ).validate_python(dialogues)
             except ValidationError as e:
                 logger.error(f"File {data} data validation error: {e}")
                 return []
@@ -49,7 +59,9 @@ class DataParser(InputParser):
                 dialogues = validation
             elif isinstance(validation[0], DialogueMessage):
                 dialogues = [Dialogue(messages=validation)]
-            elif isinstance(validation[0], List) and isinstance(validation[0][0], DialogueMessage):
+            elif isinstance(validation[0], List) and isinstance(
+                validation[0][0], DialogueMessage
+            ):
                 dialogues = [Dialogue(messages=dialogue) for dialogue in validation]
         else:
             dialogues = []

--- a/dialogue2graph/pipelines/model_storage.py
+++ b/dialogue2graph/pipelines/model_storage.py
@@ -37,8 +37,12 @@ class StoredData(BaseModel):
 
     key: str = Field(description="Key for the stored model")
     config: dict = Field(description="Configuration for the stored model")
-    model_type: Union[Literal["llm"], Literal["emb"]] = Field(description="Type of the stored model")
-    model: Union[HuggingFaceEmbeddings, BaseChatModel] = Field(description="Model object")
+    model_type: Union[Literal["llm"], Literal["emb"]] = Field(
+        description="Type of the stored model"
+    )
+    model: Union[HuggingFaceEmbeddings, BaseChatModel] = Field(
+        description="Model object"
+    )
 
     @model_validator(mode="before")
     def validate_model(cls, values):
@@ -47,7 +51,9 @@ class StoredData(BaseModel):
                 raise ValueError("LLM model must be an instance of BaseChatModel")
         elif values.get("model_type") == "emb":
             if not isinstance(values.get("model"), HuggingFaceEmbeddings):
-                raise ValueError("Embedding model must be an instance of HuggingFaceEmbeddings")
+                raise ValueError(
+                    "Embedding model must be an instance of HuggingFaceEmbeddings"
+                )
         return values
 
     class Config:
@@ -99,14 +105,18 @@ class ModelStorage(BaseModel):
             with open(path, "r") as f:
                 loaded_storage = yaml.safe_load(f)
                 for key, config in loaded_storage.items():
-                    self.add(key=key, config=config, model_type=config.pop("model_type"))
+                    self.add(
+                        key=key, config=config, model_type=config.pop("model_type")
+                    )
                     logger.debug(f"Loaded model configuration for '{key}'")
             logger.info(f"Successfully loaded {len(loaded_storage)} models from {path}")
         except Exception as e:
             logger.error(f"Failed to load model configurations from {path}: {e}")
             raise
 
-    def add(self, key: str, config: dict, model_type: Union[Literal["llm"], Literal["emb"]]):
+    def add(
+        self, key: str, config: dict, model_type: Union[Literal["llm"], Literal["emb"]]
+    ):
         """
         Add a new model configuration to the storage.
         Args:
@@ -121,17 +131,23 @@ class ModelStorage(BaseModel):
             logger.warning(f"Key '{key}' already exists in storage. Overwriting.")
         try:
             if model_type == "llm":
-                logger.debug(f"Initializing LLM model for key '{key}' with config: {config}")
+                logger.debug(
+                    f"Initializing LLM model for key '{key}' with config: {config}"
+                )
                 model_instance = ChatOpenAI(**config)
             elif model_type == "emb":
                 device = config.pop("device", None)
                 if device:
                     config["model_kwargs"] = {"device": device}
-                logger.debug(f"Initializing embedding model for key '{key}' with config: {config}")
+                logger.debug(
+                    f"Initializing embedding model for key '{key}' with config: {config}"
+                )
                 model_instance = HuggingFaceEmbeddings(**config)
 
             logger.debug("Created model instance of type: %s", type(model_instance))
-            item = StoredData(key=key, config=config, model_type=model_type, model=model_instance)
+            item = StoredData(
+                key=key, config=config, model_type=model_type, model=model_instance
+            )
             self.storage[key] = item
             logger.info(f"Added {model_type} model '{key}' to storage")
         except Exception as e:

--- a/dialogue2graph/pipelines/topic_generation/__init__.py
+++ b/dialogue2graph/pipelines/topic_generation/__init__.py
@@ -1,1 +1,1 @@
-from .pipeline import TopicGenerationPipeline
+from .pipeline import TopicGenerationPipeline as TopicGenerationPipeline

--- a/dialogue2graph/utils/dg_helper.py
+++ b/dialogue2graph/utils/dg_helper.py
@@ -6,7 +6,9 @@ from dialogue2graph.metrics.similarity import compare_strings
 from langchain_community.embeddings import HuggingFaceEmbeddings
 
 
-def connect_nodes(nodes: list, dialogues: list[Dialogue], utt_sim: HuggingFaceEmbeddings) -> dict:
+def connect_nodes(
+    nodes: list, dialogues: list[Dialogue], utt_sim: HuggingFaceEmbeddings
+) -> dict:
     """Connecting dialogue graph nodes with edges via searching dialogue utterances in list of nodes based on utt_sim similarity model
     Input: nodes and list of dialogues
     """
@@ -21,14 +23,43 @@ def connect_nodes(nodes: list, dialogues: list[Dialogue], utt_sim: HuggingFaceEm
                 if ids:
                     for id, s in zip(ids, store.get_user(ids=ids)):
                         if len(texts) > 2 * (int(id) + 1):
-                            target = node_store.find_node(texts[2 * (int(id) + 1)]["text"])
-                            existing = [e for e in edges if e["source"] == n["id"] and e["target"] == target]
+                            target = node_store.find_node(
+                                texts[2 * (int(id) + 1)]["text"]
+                            )
+                            existing = [
+                                e
+                                for e in edges
+                                if e["source"] == n["id"] and e["target"] == target
+                            ]
                             if existing:
-                                if not any([compare_strings(e, s, utt_sim) for e in existing[0]["utterances"]]):
-                                    edges = [e for e in edges if e["source"] != n["id"] or e["target"] != target]
-                                    edges.append({"source": n["id"], "target": target, "utterances": existing[0]["utterances"] + [s]})
+                                if not any(
+                                    [
+                                        compare_strings(e, s, utt_sim)
+                                        for e in existing[0]["utterances"]
+                                    ]
+                                ):
+                                    edges = [
+                                        e
+                                        for e in edges
+                                        if e["source"] != n["id"]
+                                        or e["target"] != target
+                                    ]
+                                    edges.append(
+                                        {
+                                            "source": n["id"],
+                                            "target": target,
+                                            "utterances": existing[0]["utterances"]
+                                            + [s],
+                                        }
+                                    )
                             else:
-                                edges.append({"source": n["id"], "target": target, "utterances": [s]})
+                                edges.append(
+                                    {
+                                        "source": n["id"],
+                                        "target": target,
+                                        "utterances": [s],
+                                    }
+                                )
     return {"edges": edges, "nodes": nodes}
 
 

--- a/dialogue2graph/utils/prompt_caching.py
+++ b/dialogue2graph/utils/prompt_caching.py
@@ -115,7 +115,9 @@ def setup_cache(use_in_memory: bool = False):
 
         database_url = os.getenv("DATABASE_URL")
         if not database_url:
-            logger.warning("DATABASE_URL not found in environment, falling back to in-memory cache")
+            logger.warning(
+                "DATABASE_URL not found in environment, falling back to in-memory cache"
+            )
             return setup_cache(use_in_memory=True)
 
         engine = create_engine(database_url)

--- a/dialogue2graph/utils/vector_stores.py
+++ b/dialogue2graph/utils/vector_stores.py
@@ -16,12 +16,17 @@ class DialogueStore:
     score_threshold: int
 
     def _load_dialogue(self, dialogue: list, embedder: HuggingFaceEmbeddings):
-
-        self.assistant_store = Chroma(collection_name=str(uuid.uuid4()), embedding_function=embedder)
-        self.user_store = Chroma(collection_name=str(uuid.uuid4()), embedding_function=embedder)
+        self.assistant_store = Chroma(
+            collection_name=str(uuid.uuid4()), embedding_function=embedder
+        )
+        self.user_store = Chroma(
+            collection_name=str(uuid.uuid4()), embedding_function=embedder
+        )
         assistant = [
             Document(page_content=d["text"].lower(), id=id, metadata={"id": id})
-            for id, d in enumerate([d for d in dialogue if d["participant"] == "assistant"])
+            for id, d in enumerate(
+                [d for d in dialogue if d["participant"] == "assistant"]
+            )
         ]
         user = [
             Document(page_content=d["text"].lower(), id=id, metadata={"id": id})
@@ -32,7 +37,9 @@ class DialogueStore:
         self.assistant_store.add_documents(documents=assistant)
         self.user_store.add_documents(documents=user)
 
-    def __init__(self, dialogue: list, embedder: HuggingFaceEmbeddings, score_threshold=0.995):
+    def __init__(
+        self, dialogue: list, embedder: HuggingFaceEmbeddings, score_threshold=0.995
+    ):
         self.score_threshold = score_threshold
         self._load_dialogue(dialogue, embedder)
 
@@ -40,7 +47,9 @@ class DialogueStore:
         """search for utterance over assistant store
         return found documents ids"""
         docs = self.assistant_store.similarity_search_with_relevance_scores(
-            utterance.lower(), k=self.assistant_size, score_threshold=self.score_threshold
+            utterance.lower(),
+            k=self.assistant_size,
+            score_threshold=self.score_threshold,
         )
         res = [d[0].metadata["id"] for d in docs]
         res.sort()
@@ -61,10 +70,14 @@ class NodeStore:
     utterances: list[tuple[str, int]] = []
 
     def _load_nodes(self, nodes: list, utt_sim: HuggingFaceEmbeddings):
-
-        self.nodes_store = Chroma(collection_name=str(uuid.uuid4()), embedding_function=utt_sim)
+        self.nodes_store = Chroma(
+            collection_name=str(uuid.uuid4()), embedding_function=utt_sim
+        )
         self.utterances = [(u.lower(), n["id"]) for n in nodes for u in n["utterances"]]
-        docs = [Document(page_content=u[0], id=id, metadata={"id": id}) for id, u in enumerate(self.utterances)]
+        docs = [
+            Document(page_content=u[0], id=id, metadata={"id": id})
+            for id, u in enumerate(self.utterances)
+        ]
 
         self.nodes_store.add_documents(documents=docs)
 
@@ -73,7 +86,9 @@ class NodeStore:
 
     def find_node(self, utterance: str):
         """Search for node with utterance, return node id or None if not found"""
-        docs = self.nodes_store.similarity_search_with_relevance_scores(utterance.lower(), k=1, score_threshold=0.9)
+        docs = self.nodes_store.similarity_search_with_relevance_scores(
+            utterance.lower(), k=1, score_threshold=0.9
+        )
         if docs:
             return self.utterances[docs[0][0].metadata["id"]][1]
         return None

--- a/poetry.lock
+++ b/poetry.lock
@@ -465,52 +465,6 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-name = "black"
-version = "25.1.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "black-25.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32"},
-    {file = "black-25.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da"},
-    {file = "black-25.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7"},
-    {file = "black-25.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9"},
-    {file = "black-25.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0"},
-    {file = "black-25.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299"},
-    {file = "black-25.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096"},
-    {file = "black-25.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2"},
-    {file = "black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b"},
-    {file = "black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc"},
-    {file = "black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f"},
-    {file = "black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba"},
-    {file = "black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f"},
-    {file = "black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3"},
-    {file = "black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171"},
-    {file = "black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18"},
-    {file = "black-25.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a1ee0a0c330f7b5130ce0caed9936a904793576ef4d2b98c40835d6a65afa6a0"},
-    {file = "black-25.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"},
-    {file = "black-25.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9e6827d563a2c820772b32ce8a42828dc6790f095f441beef18f96aa6f8294e"},
-    {file = "black-25.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:bacabb307dca5ebaf9c118d2d2f6903da0d62c9faa82bd21a33eecc319559355"},
-    {file = "black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717"},
-    {file = "black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.10)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "bleach"
 version = "6.2.0"
 description = "An easy safelist-based HTML-sanitizing tool."
@@ -1287,22 +1241,6 @@ files = [
 docs = ["furo (>=2024.8.6)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
 testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "diff-cover (>=9.2.1)", "pytest (>=8.3.4)", "pytest-asyncio (>=0.25.2)", "pytest-cov (>=6)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.28.1)"]
 typing = ["typing-extensions (>=4.12.2)"]
-
-[[package]]
-name = "flake8"
-version = "7.2.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "flake8-7.2.0-py2.py3-none-any.whl", hash = "sha256:93b92ba5bdb60754a6da14fa3b93a9361fd00a59632ada61fd7b130436c40343"},
-    {file = "flake8-7.2.0.tar.gz", hash = "sha256:fa558ae3f6f7dbf2b4f22663e5343b6b6023620461f8d4ff2019ef4b5ee70426"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.13.0,<2.14.0"
-pyflakes = ">=3.3.0,<3.4.0"
 
 [[package]]
 name = "flatbuffers"
@@ -2086,21 +2024,6 @@ files = [
 
 [package.dependencies]
 arrow = ">=0.15.0"
-
-[[package]]
-name = "isort"
-version = "6.0.1"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.9.0"
-files = [
-    {file = "isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615"},
-    {file = "isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450"},
-]
-
-[package.extras]
-colors = ["colorama"]
-plugins = ["setuptools"]
 
 [[package]]
 name = "jedi"
@@ -3090,17 +3013,6 @@ files = [
 traitlets = "*"
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
-
-[[package]]
 name = "mdit-py-plugins"
 version = "0.4.2"
 description = "Collection of plugins for markdown-it-py"
@@ -3272,103 +3184,103 @@ tests = ["pytest (>=4.6)"]
 
 [[package]]
 name = "multidict"
-version = "6.3.1"
+version = "6.2.0"
 description = "multidict implementation"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "multidict-6.3.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:36304aca2ba2a978b2a8741af1f9a80ca56db79f2fdebc7c3105c744f5c6dc59"},
-    {file = "multidict-6.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:723efe6fafcba47f95886819591b8324e868791ecd51879605031f551d5eb54b"},
-    {file = "multidict-6.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1f3a25a15895d9e16ef1ba8ee8002d7874dbfc901d7346680eef3c000c2fcd6"},
-    {file = "multidict-6.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a0265e2767b00a85fe6edf72dd4cec18f270cfa63e4a7e75692b7f237a98177"},
-    {file = "multidict-6.3.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66d71df2028b93c4682048ae01a0d47d42abdea70a363cb9fcf5e028a4f960be"},
-    {file = "multidict-6.3.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2a2f61f2df1a664c9d84cc403620f26eb39527484a57a5ae197f693ed1af0d25"},
-    {file = "multidict-6.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:330f6e8f366b561556ba3fcadad008658bcc6edae05ec30d3bf8285240266b84"},
-    {file = "multidict-6.3.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:442e8521f84873ed10f4cac3c93d7ca4ab137f9571f74c078b997993b9f484cf"},
-    {file = "multidict-6.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d630b2153e7b586d2a1fd18c109e0cd0470d59ce6c14dc4ca4fa3cb34b817e8b"},
-    {file = "multidict-6.3.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:bf70f4215b33028be57dac84791836b7aa294b88ef270c0c2dc78f1c7a0768d9"},
-    {file = "multidict-6.3.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:e28b2aef08b117ee18649286c63074f8dcf89ab740b95c62dab96952e6194f11"},
-    {file = "multidict-6.3.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:c42fe40faaf11930c1020e67f59170ffffad667aabf26fd68243c99c6b2d8eef"},
-    {file = "multidict-6.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0c6ca5349d6a993ccf441c0a511986e564286ef16bd931476f775a1f3675c22a"},
-    {file = "multidict-6.3.1-cp310-cp310-win32.whl", hash = "sha256:0d66ad837f68c3c1d4f784fbbbca2098c21000391da5389922c5ca20e02f3e48"},
-    {file = "multidict-6.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:eed3acd4483941605ecee781fe1ba84e4c7afefbbec0bdfe1da1858f135b15f8"},
-    {file = "multidict-6.3.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:818af177e8ed6040d980b2c931872fbda1cd96780540491324b7bd5b2791d012"},
-    {file = "multidict-6.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:257a96af4b58f94ddc198d414bac15ae43ca55406b79d9e241d0c16da1419ea1"},
-    {file = "multidict-6.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b7e44e02c7f383571ec39b2532d6f1c28c7b1af637d1b46bb0a67c4d9a649baa"},
-    {file = "multidict-6.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:60d576e62b498c888f83b6a924a560123fb7b76acae0fa629382635dd486112c"},
-    {file = "multidict-6.3.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d7407537d36e294c794a7860e16978bb4c2211de2c7772a7e8e10eca47262d8b"},
-    {file = "multidict-6.3.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81c6c87e015b381f2e3974614da1fdac45cafeaf74beb46821389edee408f540"},
-    {file = "multidict-6.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cad66c35d4d565952eaf55a91be50c2433068ea1e71f0647ffb25222e954e01c"},
-    {file = "multidict-6.3.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a0a1f61aafda969979806795bd36310bf424ad00fa5ec5e949d13021080e5325"},
-    {file = "multidict-6.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a54907daf359affa16a94d56044ac9b565b70b3c57bf6e2d52d2d8a61177eae1"},
-    {file = "multidict-6.3.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c640be28ee1a51f028793cac0d07414df9a19e0ca5d9ec3cfa872a0f266ca333"},
-    {file = "multidict-6.3.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:c3f7c8ce2451f4c820f4ea28c3a3bd794269903eaf0967f19081f2a345e46492"},
-    {file = "multidict-6.3.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:0bb725538b9feb05d5a0f2a657d14a3de2688ecfdb9c06c3773b1e0311352d6b"},
-    {file = "multidict-6.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:17398bf3ec71e24823910fb7ac671dcd29b4d48c54a22d9c65318f80e000256a"},
-    {file = "multidict-6.3.1-cp311-cp311-win32.whl", hash = "sha256:48bd65b6d905ce11a707908391456fba2c8f3bcab2017ea5042ccd225e4d7d02"},
-    {file = "multidict-6.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:79bdf29cd48606bb55ea989a59a950226a66d3adb34b8d224d6bd0b54781b693"},
-    {file = "multidict-6.3.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9679106633695b132ebc9191ec6230bfb1415d37c483833fcef2b35a2e8665ec"},
-    {file = "multidict-6.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:73a43b3b2409aa395cce91b7471cff6b45814548063b18412162ba2222084201"},
-    {file = "multidict-6.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1ce924e24c4f1c014f2ed8782e82a5232d5f61293fc5c204d8569f451191ffa8"},
-    {file = "multidict-6.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:123b1d48eeed2ac1126be078deb88006f871559787cefc8759a884442a6f2cdc"},
-    {file = "multidict-6.3.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6d98447906885e7f0f90456cde1d14ff41f30d9d7e127ab7140a45e784a0ff1b"},
-    {file = "multidict-6.3.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5072a9efe7f7f79d3dff1f26ac41e4893478f85ce55fe5318625f7eb703d76f8"},
-    {file = "multidict-6.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbc825b34595fe43966242e30b54d29617013e51b4310134aa2c16c3b3d00c91"},
-    {file = "multidict-6.3.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:baec41c191855f92507f9e0bb182eea7eea5992d649f9c712c96a38076e59d00"},
-    {file = "multidict-6.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:eacd4036bb3d632828702a076458d660b53d12e049155eaeb7d11a91242d67b8"},
-    {file = "multidict-6.3.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:284737db826cc00fbd5292225717492f037afa404a2ddfea812cfbef7a3f0e93"},
-    {file = "multidict-6.3.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ebd121433f5d8707379f4fc0e6b4bf67b0b7cd1a7132e097ead2713c8d661a41"},
-    {file = "multidict-6.3.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31f94d64672487570c7c2bbcff74311055066e013545714b938786843eb54ef8"},
-    {file = "multidict-6.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:739fe3fde8b8aca7219048f8bda17901afb8710c93307dc0d740014d3481b36b"},
-    {file = "multidict-6.3.1-cp312-cp312-win32.whl", hash = "sha256:891a94a056de2d904cc30f40ec1d111aebb09abd33089a34631ff5a19e0167b2"},
-    {file = "multidict-6.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:d9844e0f93405a9c5bc2106d48cf82e022e18685baebea74cc5057ca2009799e"},
-    {file = "multidict-6.3.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8f2c9b2d2084efab0ef8b694dab55ab3675359e00136e6707bef96be19db5ed9"},
-    {file = "multidict-6.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9678f5ecb8dc7380c11342ea3f9c2a43b90d1c2a081f22eb428bb923816ca94e"},
-    {file = "multidict-6.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6c242643c6c6a256ce220da3058c7c6074b62769136a8b463556f06ba88274b"},
-    {file = "multidict-6.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:398f80e44df494d9a2319417cb560e86aab10f1feea48099bed0fdbd2e17d640"},
-    {file = "multidict-6.3.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fdc33b92c558bb3f037e638ad4607e2765ceab5345762c82c4562328066ea4d8"},
-    {file = "multidict-6.3.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:da49eb28c5961dc0f66e020218be69681b2d0b04abfbce1d7541f2ed15321be0"},
-    {file = "multidict-6.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a5359269504f9ca8e88d68ce25eb523c9b599c843039708ca0eb1575cf55a9d"},
-    {file = "multidict-6.3.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1dcbca567085f19605e0c613b4ecca9bb1fa65325e4ace41b00cd383fb1c9573"},
-    {file = "multidict-6.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2552809ad6b6e3b3ac5ce4b16d1b641ad4f33f309747a7ba79bb433505796a6d"},
-    {file = "multidict-6.3.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d31c72dd409ffc18ca255241fb928575a6921b3876220c3602487ebf32cecf29"},
-    {file = "multidict-6.3.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c712dbaaa609f57100c475904ebd14dde27040bb52b2f08d0393da059e35ec2a"},
-    {file = "multidict-6.3.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c5821bebe862283dc349f2198a617085b7179d9324971c13c7692f5da8951c2e"},
-    {file = "multidict-6.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a566f0b8788ad5c5cc42a0b228bf1cd8f20053ff8cb8149f610763750aa6590f"},
-    {file = "multidict-6.3.1-cp313-cp313-win32.whl", hash = "sha256:0c2f11f250355d1dea7b1f09b8245c3b7a0ca99bc089670d072960a6d66d86e4"},
-    {file = "multidict-6.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:3ed86bec95a958fa789ed824cd756df0e44c2a137947c9baff9d6127c69dd697"},
-    {file = "multidict-6.3.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:231c371ff30162f1c4019e252147c6d25b3bb5412c5ef1574edafea360a2ad63"},
-    {file = "multidict-6.3.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2fb4c7b9204ba463f8377ba3dc5990803a89ee34b34d3dd81c6f94a25f8b4791"},
-    {file = "multidict-6.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c8e12b28f045392ec9a97eedcd8518ef060571df393f7c7e31a1fb59a902030e"},
-    {file = "multidict-6.3.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4587038ad21ac72e5ab3abba56aa6f5b3fe6039135a8041d15e18db036900a4d"},
-    {file = "multidict-6.3.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:729d427085527fd1a016347847221b9628eeb91843c0531ba46e773a80f13b14"},
-    {file = "multidict-6.3.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:358edbfb2977965fd04b60d82a852ed080a150580723445580e11926ec887453"},
-    {file = "multidict-6.3.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc1df4fa44282961591b7db3858be878a99f42f9354b3aa0175764070c885fe2"},
-    {file = "multidict-6.3.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d323eda78c74991efa910cac3034146f5e5012ac052d148e9bb60da177b9eda"},
-    {file = "multidict-6.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:badb5a21861bfa8865f2883339a218ee6268fe98e22c9c6f44b72a2c3e9fa5df"},
-    {file = "multidict-6.3.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:4de22e401b2d55643585d97e5b91940fb590f4d6fdd63da35519ee1e58c7b892"},
-    {file = "multidict-6.3.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8b5bf828804b5bd20425432e61ff6d9e782943e8e52550541735882945447c72"},
-    {file = "multidict-6.3.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:c7ef102290eb42190b6c155f76eb5824a2f015ad57e64e828b5960fa86dc5e12"},
-    {file = "multidict-6.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b4bc8042eef9222e8379cb0663c1213062d9e92183274acc7fd0ca5cdc0af670"},
-    {file = "multidict-6.3.1-cp313-cp313t-win32.whl", hash = "sha256:d839731885fe00068d570f815e28c2712d0221db1dfb7b70239b303a56c54410"},
-    {file = "multidict-6.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:ea0db870c1729a85a98a34f92e5a4806521ac8af9b0ebd9cd3dbf9d5e493657f"},
-    {file = "multidict-6.3.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:87b61c4f8beda0ad6c0f4ff4187465c30fb3ea4f210f173f9b08ab669e04f398"},
-    {file = "multidict-6.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:af597a9056d690708bea8489d37974625a7c7b91ecb5dd4d235582f4f3646718"},
-    {file = "multidict-6.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e2bf3fb4021b90ffddcedcb976c32ca40217c4270c93098f6a2dc798694c6141"},
-    {file = "multidict-6.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:745073a7189cd5624656f91cab541f3f2598d9cd289869840dbdb50b97287331"},
-    {file = "multidict-6.3.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26ca60766498c3343d6186a74b8387d1f901b3a28914b32cd9446acc4d38f065"},
-    {file = "multidict-6.3.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88cbdd5535f31fbfacfd36e187374d21ab90a45b15104a9cbbd4b5a1af264b69"},
-    {file = "multidict-6.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56d169d487dce3377b9096ce9add0179de13852e927b4be50aa6e184cabc2ef9"},
-    {file = "multidict-6.3.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bac7e3f30f15574c5c4ecd88bdfed7f22e19dbc43994b1b9f2ed48a7bd359e12"},
-    {file = "multidict-6.3.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:bae294fb34de44972fbfd819b2564836a1174f08841672fc792ff8ddc9259341"},
-    {file = "multidict-6.3.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:e8d2af9147c554aa7ae7d3eb12524f9f4dc6b6dcbdc3634cc35f07effdac36e9"},
-    {file = "multidict-6.3.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:1a7c81c9e3ae31c1ab12eea10c8a2b9d27a1a367f5d972b23d9cbca101bd8cea"},
-    {file = "multidict-6.3.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:646301a3959a76e542daffedd198968dc5d471764255b42e494c659ffcfc0f9d"},
-    {file = "multidict-6.3.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:9953a2df449036292d8ab1af99e1bfdf6343bef3afb6c12600314dfa44de188b"},
-    {file = "multidict-6.3.1-cp39-cp39-win32.whl", hash = "sha256:a8fec1c4768dccf4bda9c8fe2f99ccf7683df88623949bad8ea242035a28c781"},
-    {file = "multidict-6.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:0725b731787670330346f2f3cbcf4776e614916a3e9eadede34154558599e998"},
-    {file = "multidict-6.3.1-py3-none-any.whl", hash = "sha256:2d45b070b33fa1d0a9a7650469997713e3a4f5cd9eb564332d5d0206cf61efc5"},
-    {file = "multidict-6.3.1.tar.gz", hash = "sha256:3e18d6afe3f855736022748606def2000af18e90253fb8b4d698b51f61e21283"},
+    {file = "multidict-6.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b9f6392d98c0bd70676ae41474e2eecf4c7150cb419237a41f8f96043fcb81d1"},
+    {file = "multidict-6.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3501621d5e86f1a88521ea65d5cad0a0834c77b26f193747615b7c911e5422d2"},
+    {file = "multidict-6.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:32ed748ff9ac682eae7859790d3044b50e3076c7d80e17a44239683769ff485e"},
+    {file = "multidict-6.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc826b9a8176e686b67aa60fd6c6a7047b0461cae5591ea1dc73d28f72332a8a"},
+    {file = "multidict-6.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:214207dcc7a6221d9942f23797fe89144128a71c03632bf713d918db99bd36de"},
+    {file = "multidict-6.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:05fefbc3cddc4e36da209a5e49f1094bbece9a581faa7f3589201fd95df40e5d"},
+    {file = "multidict-6.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e851e6363d0dbe515d8de81fd544a2c956fdec6f8a049739562286727d4a00c3"},
+    {file = "multidict-6.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32c9b4878f48be3e75808ea7e499d6223b1eea6d54c487a66bc10a1871e3dc6a"},
+    {file = "multidict-6.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7243c5a6523c5cfeca76e063efa5f6a656d1d74c8b1fc64b2cd1e84e507f7e2a"},
+    {file = "multidict-6.2.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0e5a644e50ef9fb87878d4d57907f03a12410d2aa3b93b3acdf90a741df52c49"},
+    {file = "multidict-6.2.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:0dc25a3293c50744796e87048de5e68996104d86d940bb24bc3ec31df281b191"},
+    {file = "multidict-6.2.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:a49994481b99cd7dedde07f2e7e93b1d86c01c0fca1c32aded18f10695ae17eb"},
+    {file = "multidict-6.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:641cf2e3447c9ecff2f7aa6e9eee9eaa286ea65d57b014543a4911ff2799d08a"},
+    {file = "multidict-6.2.0-cp310-cp310-win32.whl", hash = "sha256:0c383d28857f66f5aebe3e91d6cf498da73af75fbd51cedbe1adfb85e90c0460"},
+    {file = "multidict-6.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:a33273a541f1e1a8219b2a4ed2de355848ecc0254264915b9290c8d2de1c74e1"},
+    {file = "multidict-6.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:84e87a7d75fa36839a3a432286d719975362d230c70ebfa0948549cc38bd5b46"},
+    {file = "multidict-6.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8de4d42dffd5ced9117af2ce66ba8722402541a3aa98ffdf78dde92badb68932"},
+    {file = "multidict-6.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7d91a230c7f8af86c904a5a992b8c064b66330544693fd6759c3d6162382ecf"},
+    {file = "multidict-6.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f6cad071960ba1914fa231677d21b1b4a3acdcce463cee41ea30bc82e6040cf"},
+    {file = "multidict-6.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f74f2fc51555f4b037ef278efc29a870d327053aba5cb7d86ae572426c7cccc"},
+    {file = "multidict-6.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:14ed9ed1bfedd72a877807c71113deac292bf485159a29025dfdc524c326f3e1"},
+    {file = "multidict-6.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ac3fcf9a2d369bd075b2c2965544036a27ccd277fc3c04f708338cc57533081"},
+    {file = "multidict-6.2.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fc6af8e39f7496047c7876314f4317736eac82bf85b54c7c76cf1a6f8e35d98"},
+    {file = "multidict-6.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5f8cb1329f42fadfb40d6211e5ff568d71ab49be36e759345f91c69d1033d633"},
+    {file = "multidict-6.2.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5389445f0173c197f4a3613713b5fb3f3879df1ded2a1a2e4bc4b5b9c5441b7e"},
+    {file = "multidict-6.2.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:94a7bb972178a8bfc4055db80c51efd24baefaced5e51c59b0d598a004e8305d"},
+    {file = "multidict-6.2.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:da51d8928ad8b4244926fe862ba1795f0b6e68ed8c42cd2f822d435db9c2a8f4"},
+    {file = "multidict-6.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:063be88bd684782a0715641de853e1e58a2f25b76388538bd62d974777ce9bc2"},
+    {file = "multidict-6.2.0-cp311-cp311-win32.whl", hash = "sha256:52b05e21ff05729fbea9bc20b3a791c3c11da61649ff64cce8257c82a020466d"},
+    {file = "multidict-6.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:1e2a2193d3aa5cbf5758f6d5680a52aa848e0cf611da324f71e5e48a9695cc86"},
+    {file = "multidict-6.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:437c33561edb6eb504b5a30203daf81d4a9b727e167e78b0854d9a4e18e8950b"},
+    {file = "multidict-6.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9f49585f4abadd2283034fc605961f40c638635bc60f5162276fec075f2e37a4"},
+    {file = "multidict-6.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5dd7106d064d05896ce28c97da3f46caa442fe5a43bc26dfb258e90853b39b44"},
+    {file = "multidict-6.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e25b11a0417475f093d0f0809a149aff3943c2c56da50fdf2c3c88d57fe3dfbd"},
+    {file = "multidict-6.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac380cacdd3b183338ba63a144a34e9044520a6fb30c58aa14077157a033c13e"},
+    {file = "multidict-6.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:61d5541f27533f803a941d3a3f8a3d10ed48c12cf918f557efcbf3cd04ef265c"},
+    {file = "multidict-6.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:facaf11f21f3a4c51b62931feb13310e6fe3475f85e20d9c9fdce0d2ea561b87"},
+    {file = "multidict-6.2.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:095a2eabe8c43041d3e6c2cb8287a257b5f1801c2d6ebd1dd877424f1e89cf29"},
+    {file = "multidict-6.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0cc398350ef31167e03f3ca7c19313d4e40a662adcb98a88755e4e861170bdd"},
+    {file = "multidict-6.2.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7c611345bbe7cb44aabb877cb94b63e86f2d0db03e382667dbd037866d44b4f8"},
+    {file = "multidict-6.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8cd1a0644ccaf27e9d2f6d9c9474faabee21f0578fe85225cc5af9a61e1653df"},
+    {file = "multidict-6.2.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:89b3857652183b8206a891168af47bac10b970d275bba1f6ee46565a758c078d"},
+    {file = "multidict-6.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:125dd82b40f8c06d08d87b3510beaccb88afac94e9ed4a6f6c71362dc7dbb04b"},
+    {file = "multidict-6.2.0-cp312-cp312-win32.whl", hash = "sha256:76b34c12b013d813e6cb325e6bd4f9c984db27758b16085926bbe7ceeaace626"},
+    {file = "multidict-6.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:0b183a959fb88ad1be201de2c4bdf52fa8e46e6c185d76201286a97b6f5ee65c"},
+    {file = "multidict-6.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5c5e7d2e300d5cb3b2693b6d60d3e8c8e7dd4ebe27cd17c9cb57020cac0acb80"},
+    {file = "multidict-6.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:256d431fe4583c5f1e0f2e9c4d9c22f3a04ae96009b8cfa096da3a8723db0a16"},
+    {file = "multidict-6.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a3c0ff89fe40a152e77b191b83282c9664357dce3004032d42e68c514ceff27e"},
+    {file = "multidict-6.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef7d48207926edbf8b16b336f779c557dd8f5a33035a85db9c4b0febb0706817"},
+    {file = "multidict-6.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3c099d3899b14e1ce52262eb82a5f5cb92157bb5106bf627b618c090a0eadc"},
+    {file = "multidict-6.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e16e7297f29a544f49340012d6fc08cf14de0ab361c9eb7529f6a57a30cbfda1"},
+    {file = "multidict-6.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:042028348dc5a1f2be6c666437042a98a5d24cee50380f4c0902215e5ec41844"},
+    {file = "multidict-6.2.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:08549895e6a799bd551cf276f6e59820aa084f0f90665c0f03dd3a50db5d3c48"},
+    {file = "multidict-6.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ccfd74957ef53fa7380aaa1c961f523d582cd5e85a620880ffabd407f8202c0"},
+    {file = "multidict-6.2.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83b78c680d4b15d33042d330c2fa31813ca3974197bddb3836a5c635a5fd013f"},
+    {file = "multidict-6.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b4c153863dd6569f6511845922c53e39c8d61f6e81f228ad5443e690fca403de"},
+    {file = "multidict-6.2.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:98aa8325c7f47183b45588af9c434533196e241be0a4e4ae2190b06d17675c02"},
+    {file = "multidict-6.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9e658d1373c424457ddf6d55ec1db93c280b8579276bebd1f72f113072df8a5d"},
+    {file = "multidict-6.2.0-cp313-cp313-win32.whl", hash = "sha256:3157126b028c074951839233647bd0e30df77ef1fedd801b48bdcad242a60f4e"},
+    {file = "multidict-6.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:2e87f1926e91855ae61769ba3e3f7315120788c099677e0842e697b0bfb659f2"},
+    {file = "multidict-6.2.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2529ddbdaa424b2c6c2eb668ea684dd6b75b839d0ad4b21aad60c168269478d7"},
+    {file = "multidict-6.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:13551d0e2d7201f0959725a6a769b6f7b9019a168ed96006479c9ac33fe4096b"},
+    {file = "multidict-6.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d1996ee1330e245cd3aeda0887b4409e3930524c27642b046e4fae88ffa66c5e"},
+    {file = "multidict-6.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c537da54ce4ff7c15e78ab1292e5799d0d43a2108e006578a57f531866f64025"},
+    {file = "multidict-6.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f249badb360b0b4d694307ad40f811f83df4da8cef7b68e429e4eea939e49dd"},
+    {file = "multidict-6.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48d39b1824b8d6ea7de878ef6226efbe0773f9c64333e1125e0efcfdd18a24c7"},
+    {file = "multidict-6.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b99aac6bb2c37db336fa03a39b40ed4ef2818bf2dfb9441458165ebe88b793af"},
+    {file = "multidict-6.2.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07bfa8bc649783e703263f783f73e27fef8cd37baaad4389816cf6a133141331"},
+    {file = "multidict-6.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b2c00ad31fbc2cbac85d7d0fcf90853b2ca2e69d825a2d3f3edb842ef1544a2c"},
+    {file = "multidict-6.2.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:0d57a01a2a9fa00234aace434d8c131f0ac6e0ac6ef131eda5962d7e79edfb5b"},
+    {file = "multidict-6.2.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:abf5b17bc0cf626a8a497d89ac691308dbd825d2ac372aa990b1ca114e470151"},
+    {file = "multidict-6.2.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:f7716f7e7138252d88607228ce40be22660d6608d20fd365d596e7ca0738e019"},
+    {file = "multidict-6.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d5a36953389f35f0a4e88dc796048829a2f467c9197265504593f0e420571547"},
+    {file = "multidict-6.2.0-cp313-cp313t-win32.whl", hash = "sha256:e653d36b1bf48fa78c7fcebb5fa679342e025121ace8c87ab05c1cefd33b34fc"},
+    {file = "multidict-6.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ca23db5fb195b5ef4fd1f77ce26cadefdf13dba71dab14dadd29b34d457d7c44"},
+    {file = "multidict-6.2.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b4f3d66dd0354b79761481fc15bdafaba0b9d9076f1f42cc9ce10d7fcbda205a"},
+    {file = "multidict-6.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6e2a2d6749e1ff2c9c76a72c6530d5baa601205b14e441e6d98011000f47a7ac"},
+    {file = "multidict-6.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cca83a629f77402cfadd58352e394d79a61c8015f1694b83ab72237ec3941f88"},
+    {file = "multidict-6.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:781b5dd1db18c9e9eacc419027b0acb5073bdec9de1675c0be25ceb10e2ad133"},
+    {file = "multidict-6.2.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cf8d370b2fea27fb300825ec3984334f7dd54a581bde6456799ba3776915a656"},
+    {file = "multidict-6.2.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:25bb96338512e2f46f615a2bb7c6012fe92a4a5ebd353e5020836a7e33120349"},
+    {file = "multidict-6.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19e2819b0b468174de25c0ceed766606a07cedeab132383f1e83b9a4e96ccb4f"},
+    {file = "multidict-6.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6aed763b6a1b28c46c055692836879328f0b334a6d61572ee4113a5d0c859872"},
+    {file = "multidict-6.2.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a1133414b771619aa3c3000701c11b2e4624a7f492f12f256aedde97c28331a2"},
+    {file = "multidict-6.2.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:639556758c36093b35e2e368ca485dada6afc2bd6a1b1207d85ea6dfc3deab27"},
+    {file = "multidict-6.2.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:163f4604e76639f728d127293d24c3e208b445b463168af3d031b92b0998bb90"},
+    {file = "multidict-6.2.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:2325105e16d434749e1be8022f942876a936f9bece4ec41ae244e3d7fae42aaf"},
+    {file = "multidict-6.2.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:e4371591e621579cb6da8401e4ea405b33ff25a755874a3567c4075ca63d56e2"},
+    {file = "multidict-6.2.0-cp39-cp39-win32.whl", hash = "sha256:d1175b0e0d6037fab207f05774a176d71210ebd40b1c51f480a04b65ec5c786d"},
+    {file = "multidict-6.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:ad81012b24b88aad4c70b2cbc2dad84018783221b7f923e926f4690ff8569da3"},
+    {file = "multidict-6.2.0-py3-none-any.whl", hash = "sha256:5d26547423e5e71dcc562c4acdc134b900640a39abd9066d7326a7cc2324c530"},
+    {file = "multidict-6.2.0.tar.gz", hash = "sha256:0085b0afb2446e57050140240a8595846ed64d1cbd26cef936bfab3192c673b8"},
 ]
 
 [package.dependencies]
@@ -3397,59 +3309,6 @@ files = [
 
 [package.dependencies]
 dill = ">=0.3.8"
-
-[[package]]
-name = "mypy"
-version = "1.15.0"
-description = "Optional static typing for Python"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "mypy-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:979e4e1a006511dacf628e36fadfecbcc0160a8af6ca7dad2f5025529e082c13"},
-    {file = "mypy-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c4bb0e1bd29f7d34efcccd71cf733580191e9a264a2202b0239da95984c5b559"},
-    {file = "mypy-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be68172e9fd9ad8fb876c6389f16d1c1b5f100ffa779f77b1fb2176fcc9ab95b"},
-    {file = "mypy-1.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7be1e46525adfa0d97681432ee9fcd61a3964c2446795714699a998d193f1a3"},
-    {file = "mypy-1.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2e2c2e6d3593f6451b18588848e66260ff62ccca522dd231cd4dd59b0160668b"},
-    {file = "mypy-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:6983aae8b2f653e098edb77f893f7b6aca69f6cffb19b2cc7443f23cce5f4828"},
-    {file = "mypy-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2922d42e16d6de288022e5ca321cd0618b238cfc5570e0263e5ba0a77dbef56f"},
-    {file = "mypy-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ee2d57e01a7c35de00f4634ba1bbf015185b219e4dc5909e281016df43f5ee5"},
-    {file = "mypy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973500e0774b85d9689715feeffcc980193086551110fd678ebe1f4342fb7c5e"},
-    {file = "mypy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a95fb17c13e29d2d5195869262f8125dfdb5c134dc8d9a9d0aecf7525b10c2c"},
-    {file = "mypy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1905f494bfd7d85a23a88c5d97840888a7bd516545fc5aaedff0267e0bb54e2f"},
-    {file = "mypy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c9817fa23833ff189db061e6d2eff49b2f3b6ed9856b4a0a73046e41932d744f"},
-    {file = "mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd"},
-    {file = "mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f"},
-    {file = "mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464"},
-    {file = "mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee"},
-    {file = "mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e"},
-    {file = "mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22"},
-    {file = "mypy-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93faf3fdb04768d44bf28693293f3904bbb555d076b781ad2530214ee53e3445"},
-    {file = "mypy-1.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:811aeccadfb730024c5d3e326b2fbe9249bb7413553f15499a4050f7c30e801d"},
-    {file = "mypy-1.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98b7b9b9aedb65fe628c62a6dc57f6d5088ef2dfca37903a7d9ee374d03acca5"},
-    {file = "mypy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c43a7682e24b4f576d93072216bf56eeff70d9140241f9edec0c104d0c515036"},
-    {file = "mypy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:baefc32840a9f00babd83251560e0ae1573e2f9d1b067719479bfb0e987c6357"},
-    {file = "mypy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b9378e2c00146c44793c98b8d5a61039a048e31f429fb0eb546d93f4b000bedf"},
-    {file = "mypy-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e601a7fa172c2131bff456bb3ee08a88360760d0d2f8cbd7a75a65497e2df078"},
-    {file = "mypy-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:712e962a6357634fef20412699a3655c610110e01cdaa6180acec7fc9f8513ba"},
-    {file = "mypy-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f95579473af29ab73a10bada2f9722856792a36ec5af5399b653aa28360290a5"},
-    {file = "mypy-1.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f8722560a14cde92fdb1e31597760dc35f9f5524cce17836c0d22841830fd5b"},
-    {file = "mypy-1.15.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1fbb8da62dc352133d7d7ca90ed2fb0e9d42bb1a32724c287d3c76c58cbaa9c2"},
-    {file = "mypy-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:d10d994b41fb3497719bbf866f227b3489048ea4bbbb5015357db306249f7980"},
-    {file = "mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e"},
-    {file = "mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43"},
-]
-
-[package.dependencies]
-mypy_extensions = ">=1.0.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing_extensions = ">=4.6.0"
-
-[package.extras]
-dmypy = ["psutil (>=4.0)"]
-faster-cache = ["orjson"]
-install-types = ["pip"]
-mypyc = ["setuptools (>=50)"]
-reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
@@ -4306,17 +4165,6 @@ files = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
 name = "pbr"
 version = "6.1.1"
 description = "Python Build Reasonableness"
@@ -4867,17 +4715,6 @@ files = [
 pyasn1 = ">=0.6.1,<0.7.0"
 
 [[package]]
-name = "pycodestyle"
-version = "2.13.0"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "pycodestyle-2.13.0-py2.py3-none-any.whl", hash = "sha256:35863c5974a271c7a726ed228a14a4f6daf49df369d8c50cd9a6f58a5e143ba9"},
-    {file = "pycodestyle-2.13.0.tar.gz", hash = "sha256:c8415bf09abe81d9c7f872502a6eee881fbe85d8763dd5b9924bb0a01d67efae"},
-]
-
-[[package]]
 name = "pycparser"
 version = "2.22"
 description = "C parser in Python"
@@ -5066,17 +4903,6 @@ dev = ["pandoc", "pre-commit", "pydata-sphinx-theme[doc,test]", "pyyaml", "sphin
 doc = ["ablog (>=0.11.8)", "colorama", "graphviz", "ipykernel", "ipyleaflet", "ipywidgets", "jupyter_sphinx", "jupyterlite-sphinx", "linkify-it-py", "matplotlib", "myst-parser", "nbsphinx", "numpy", "numpydoc", "pandas", "plotly", "rich", "sphinx-autoapi (>=3.0.0)", "sphinx-copybutton", "sphinx-design", "sphinx-favicon (>=1.0.1)", "sphinx-sitemap", "sphinx-togglebutton", "sphinxcontrib-youtube (>=1.4.1)", "sphinxext-rediraffe", "xarray"]
 i18n = ["Babel", "jinja2"]
 test = ["pytest", "pytest-cov", "pytest-regressions", "sphinx[test]"]
-
-[[package]]
-name = "pyflakes"
-version = "3.3.2"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "pyflakes-3.3.2-py2.py3-none-any.whl", hash = "sha256:5039c8339cbb1944045f4ee5466908906180f13cc99cc9949348d10f82a5c32a"},
-    {file = "pyflakes-3.3.2.tar.gz", hash = "sha256:6dfd61d87b97fba5dcfaaf781171ac16be16453be6d816147989e7f6e6a9576b"},
-]
 
 [[package]]
 name = "pygments"
@@ -5776,6 +5602,33 @@ files = [
 
 [package.dependencies]
 pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "ruff"
+version = "0.11.2"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.11.2-py3-none-linux_armv6l.whl", hash = "sha256:c69e20ea49e973f3afec2c06376eb56045709f0212615c1adb0eda35e8a4e477"},
+    {file = "ruff-0.11.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2c5424cc1c4eb1d8ecabe6d4f1b70470b4f24a0c0171356290b1953ad8f0e272"},
+    {file = "ruff-0.11.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ecf20854cc73f42171eedb66f006a43d0a21bfb98a2523a809931cda569552d9"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c543bf65d5d27240321604cee0633a70c6c25c9a2f2492efa9f6d4b8e4199bb"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20967168cc21195db5830b9224be0e964cc9c8ecf3b5a9e3ce19876e8d3a96e3"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:955a9ce63483999d9f0b8f0b4a3ad669e53484232853054cc8b9d51ab4c5de74"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:86b3a27c38b8fce73bcd262b0de32e9a6801b76d52cdb3ae4c914515f0cef608"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3b66a03b248c9fcd9d64d445bafdf1589326bee6fc5c8e92d7562e58883e30f"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0397c2672db015be5aa3d4dac54c69aa012429097ff219392c018e21f5085147"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:869bcf3f9abf6457fbe39b5a37333aa4eecc52a3b99c98827ccc371a8e5b6f1b"},
+    {file = "ruff-0.11.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2a2b50ca35457ba785cd8c93ebbe529467594087b527a08d487cf0ee7b3087e9"},
+    {file = "ruff-0.11.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7c69c74bf53ddcfbc22e6eb2f31211df7f65054bfc1f72288fc71e5f82db3eab"},
+    {file = "ruff-0.11.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6e8fb75e14560f7cf53b15bbc55baf5ecbe373dd5f3aab96ff7aa7777edd7630"},
+    {file = "ruff-0.11.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:842a472d7b4d6f5924e9297aa38149e5dcb1e628773b70e6387ae2c97a63c58f"},
+    {file = "ruff-0.11.2-py3-none-win32.whl", hash = "sha256:aca01ccd0eb5eb7156b324cfaa088586f06a86d9e5314b0eb330cb48415097cc"},
+    {file = "ruff-0.11.2-py3-none-win_amd64.whl", hash = "sha256:3170150172a8f994136c0c66f494edf199a0bbea7a409f649e4bc8f4d7084080"},
+    {file = "ruff-0.11.2-py3-none-win_arm64.whl", hash = "sha256:52933095158ff328f4c77af3d74f0379e34fd52f175144cefc1b192e7ccd32b4"},
+    {file = "ruff-0.11.2.tar.gz", hash = "sha256:ec47591497d5a1050175bdf4e1a4e6272cddff7da88a2ad595e1e326041d8d94"},
+]
 
 [[package]]
 name = "safetensors"
@@ -7694,4 +7547,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10,<3.13"
-content-hash = "6efa5555d3da8877b407a8b98f9749d218f9949c31d9643a13fbf9b6fab5462e"
+content-hash = "47dfcf492611078721748ad025fa17d50a28af2187cf098c929e25944b83a29c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,11 +58,7 @@ build-backend = "poetry.core.masonry.api"
 optional = true
 
 [tool.poetry.group.lint.dependencies]
-flake8 = "*"
-isort = "*"
-black = "*"
-mypy = "*"
-
+ruff = "*"
 
 [tool.poetry.group.tests]
 optional = true
@@ -74,12 +70,9 @@ pytest = "*"
 default_task_type = "script"
 
 [tool.poe.tasks]
-flake = "scripts.codestyle:_run_flake"
-black = "scripts.codestyle:_run_black(modify=False)"
-format = "scripts.codestyle:_run_black(modify=True)"
 test = "scripts.test:quick_test"
-metrics = "scripts.metrics:_run_check"
-lint.sequence = ["flake", "black"]
+lint = "scripts.codestyle:_check"
+format = "scripts.codestyle:_format"
 
 [tool.poetry.scripts]
 dialogue2graph = "dialogue2graph.cli.main:cli"

--- a/scripts/codestyle.py
+++ b/scripts/codestyle.py
@@ -1,37 +1,9 @@
-import pathlib
-from typing import List
+import subprocess
 
-import black
-from flake8.main.cli import main as flake_main
+def _check():
+    """Run ruff to check code style."""
+    subprocess.run(["ruff", "check", "./dialogue2graph"], check=True)
 
-
-_STANDARD_PATHS = ["dialogue2graph", "scripts", "tests", ".github"]
-_STANDARD_PATHS_LEN = 150
-
-
-def _get_paths(paths: List[str]) -> List[pathlib.Path]:
-    return [path for dir in paths for path in pathlib.Path(dir).glob("**/*.py")]
-
-
-def _run_flake():
-    lint_result = 0
-    flake8_configs = [
-        "--select=E,W,F",
-        # black formats binary operators after line breaks
-        "--ignore=E501,E203,W503,W293,F824",
-        "--per-file-ignores="
-        # allow imports in init files without use
-        "**/__init__.py:F401 ",
-    ]
-    lint_result += flake_main([f"--max-line-length={_STANDARD_PATHS_LEN}"] + flake8_configs + _STANDARD_PATHS)
-
-    exit(lint_result)
-
-
-def _run_black(modify: bool):
-    report = black.Report(check=not modify, quiet=False)
-    write = black.WriteBack.YES if modify else black.WriteBack.CHECK
-    for path in _get_paths(_STANDARD_PATHS):
-        mode = black.Mode(line_length=_STANDARD_PATHS_LEN)
-        black.reformat_one(path, False, write, mode, report)
-    exit(report.return_code)
+def _format():
+    """Run ruff to format code."""
+    subprocess.run(["ruff", "format", "./dialogue2graph"], check=True)


### PR DESCRIPTION
I suggest switching to `ruff` linter/formatter from the current `flake8, isort, black, mypy` stack.

Pros:
- more informative linting messages
- better codestyle (opinionated)
- slightly faster
- much simpler workflow and less bugs to solve
Cons:
- larger file size (~30Mb binary)
- something new